### PR TITLE
Limit Fournos to watch only own namespace jobs; fix RBAC

### DIFF
--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -19,6 +19,7 @@ spec:
       containers:
         - name: fournos
           image: quay.io/rh_perfscale/fournos:latest
+          args: ["--namespace=$(FOURNOS_NAMESPACE)"]
           env:
             - name: FOURNOS_NAMESPACE
               valueFrom:

--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -12,6 +12,9 @@ metadata:
   name: fournos
   namespace: psap-automation
 rules:
+  - apiGroups: ["fournos.dev"]
+    resources: ["fournosjobs", "fournosjobs/status"]
+    verbs: ["get", "list", "watch", "patch", "update"]
   - apiGroups: ["kueue.x-k8s.io"]
     resources: ["workloads"]
     verbs: ["create", "get", "list", "watch", "patch", "delete"]
@@ -44,6 +47,12 @@ kind: ClusterRole
 metadata:
   name: fournos-cluster
 rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["kueue.x-k8s.io"]
     resources:
       - clusterqueues


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated namespace configuration handling in service deployments
  * Enhanced service account permissions for resource management and cluster visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->