### PR TITLE
Propagate Workload and PipelineRun status into FournosJob

### DIFF
--- a/fournos/core/kueue.py
+++ b/fournos/core/kueue.py
@@ -152,6 +152,15 @@ class KueueClient:
         )
 
     @staticmethod
+    def get_pending_message(workload: dict) -> tuple[str, str]:
+        """Return (reason, message) from the most relevant Workload condition."""
+        conditions = workload.get("status", {}).get("conditions", [])
+        for c in reversed(conditions):
+            if c.get("message"):
+                return c.get("reason", ""), c.get("message", "")
+        return "", ""
+
+    @staticmethod
     def get_assigned_flavor(workload: dict) -> str | None:
         """Extract the assigned ResourceFlavor (= cluster name) from an admitted Workload."""
         admission = workload.get("status", {}).get("admission", {})

--- a/fournos/operator.py
+++ b/fournos/operator.py
@@ -3,6 +3,7 @@ Kueue Workloads + Tekton PipelineRuns."""
 
 from __future__ import annotations
 
+import datetime
 import logging
 import threading
 import time
@@ -21,6 +22,45 @@ logger = logging.getLogger(__name__)
 _kueue: KueueClient
 _tekton: TektonClient
 _registry: ClusterRegistry
+
+COND_WORKLOAD_ADMITTED = "WorkloadAdmitted"
+COND_PIPELINE_RUN_READY = "PipelineRunReady"
+
+
+def _utcnow() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _set_condition(
+    patch,
+    existing_conditions: list[dict],
+    type_: str,
+    cond_status: str,
+    reason: str,
+    message: str,
+) -> None:
+    """Upsert a condition by type, preserving lastTransitionTime when status is unchanged."""
+    now = _utcnow()
+    old = next((c for c in existing_conditions if c.get("type") == type_), None)
+
+    if old and old.get("status") == cond_status:
+        transition_time = old.get("lastTransitionTime", now)
+    else:
+        transition_time = now
+
+    new_cond: dict = {
+        "type": type_,
+        "status": cond_status,
+        "lastTransitionTime": transition_time,
+    }
+    if reason:
+        new_cond["reason"] = reason
+    if message:
+        new_cond["message"] = message
+
+    result = [c for c in existing_conditions if c.get("type") != type_]
+    result.append(new_cond)
+    patch.status["conditions"] = result
 
 
 @kopf.on.startup()
@@ -113,6 +153,16 @@ def on_create(spec, name, namespace, status, patch, **_):
             return
 
     patch.status["phase"] = "Pending"
+    patch.status["message"] = "Workload created, waiting for Kueue admission"
+    patch.status["conditions"] = [
+        {
+            "type": COND_WORKLOAD_ADMITTED,
+            "status": "False",
+            "reason": "Pending",
+            "message": "Workload created, waiting for Kueue admission",
+            "lastTransitionTime": _utcnow(),
+        }
+    ]
     logger.info("Job %s: created Workload, phase=Pending", name)
 
 
@@ -132,36 +182,72 @@ def reconcile(spec, name, namespace, status, patch, **_):
     phase = status.get("phase", "")
 
     if phase == "Pending":
-        _reconcile_pending(name, patch)
+        _reconcile_pending(name, status, patch)
     elif phase == "Admitted":
         _reconcile_admitted(spec, name, namespace, status, patch)
     elif phase == "Running":
-        _reconcile_running(name, patch)
+        _reconcile_running(name, status, patch)
 
 
-def _reconcile_pending(name, patch):
+def _reconcile_pending(name, status, patch):
     wl = _kueue.get_workload_or_none(name)
     if wl is None:
         logger.info("Job %s: Workload not yet visible", name)
         return
+
+    conditions = list(status.get("conditions") or [])
 
     if KueueClient.is_admitted(wl):
         cluster = KueueClient.get_assigned_flavor(wl)
         if not cluster:
             patch.status["phase"] = "Failed"
             patch.status["message"] = "Workload admitted but no flavor assigned"
+            _set_condition(
+                patch,
+                conditions,
+                COND_WORKLOAD_ADMITTED,
+                "False",
+                "NoFlavorAssigned",
+                "Workload was admitted but no ResourceFlavor was assigned",
+            )
             _kueue.delete_workload(name)
             logger.error("Job %s: admitted without assigned flavor", name)
             return
         patch.status["phase"] = "Admitted"
         patch.status["cluster"] = cluster
+        patch.status["message"] = f"Workload admitted, assigned to cluster {cluster}"
+        _set_condition(
+            patch,
+            conditions,
+            COND_WORKLOAD_ADMITTED,
+            "True",
+            "Admitted",
+            f"Assigned to cluster {cluster}",
+        )
         logger.info("Job %s: Workload admitted, cluster=%s", name, cluster)
     else:
+        wl_reason, wl_message = KueueClient.get_pending_message(wl)
+        new_msg = (
+            f"Waiting for admission: {wl_message}"
+            if wl_message
+            else "Waiting for Kueue admission"
+        )
+        if status.get("message") != new_msg:
+            patch.status["message"] = new_msg
+            _set_condition(
+                patch,
+                conditions,
+                COND_WORKLOAD_ADMITTED,
+                "False",
+                wl_reason or "Pending",
+                wl_message or "Workload is queued for Kueue admission",
+            )
         logger.info("Job %s: Workload pending admission", name)
 
 
 def _reconcile_admitted(spec, name, namespace, status, patch):
     pr = _tekton.get_pipeline_run_or_none(name)
+    conditions = list(status.get("conditions") or [])
 
     if pr is None:
         cluster = status.get("cluster", "")
@@ -192,6 +278,14 @@ def _reconcile_admitted(spec, name, namespace, status, patch):
             if exc.status != 409:
                 patch.status["phase"] = "Failed"
                 patch.status["message"] = f"Failed to create PipelineRun: {exc.reason}"
+                _set_condition(
+                    patch,
+                    conditions,
+                    COND_PIPELINE_RUN_READY,
+                    "False",
+                    "CreateFailed",
+                    f"Failed to create PipelineRun: {exc.reason}",
+                )
                 _kueue.delete_workload(name)
                 logger.error(
                     "Job %s: PipelineRun creation failed (HTTP %s): %s",
@@ -204,6 +298,15 @@ def _reconcile_admitted(spec, name, namespace, status, patch):
 
     patch.status["phase"] = "Running"
     patch.status["pipelineRun"] = f"fournos-{name}"
+    patch.status["message"] = "PipelineRun created, waiting for execution"
+    _set_condition(
+        patch,
+        conditions,
+        COND_PIPELINE_RUN_READY,
+        "Unknown",
+        "Started",
+        "PipelineRun has been created",
+    )
     if settings.tekton_dashboard_url:
         base = settings.tekton_dashboard_url.rstrip("/")
         patch.status["dashboardURL"] = (
@@ -211,11 +314,21 @@ def _reconcile_admitted(spec, name, namespace, status, patch):
         )
 
 
-def _reconcile_running(name, patch):
+def _reconcile_running(name, status, patch):
     pr = _tekton.get_pipeline_run_or_none(name)
+    conditions = list(status.get("conditions") or [])
+
     if pr is None:
         patch.status["phase"] = "Failed"
         patch.status["message"] = "PipelineRun not found"
+        _set_condition(
+            patch,
+            conditions,
+            COND_PIPELINE_RUN_READY,
+            "False",
+            "NotFound",
+            f"PipelineRun fournos-{name} not found",
+        )
         _kueue.delete_workload(name)
         logger.error("Job %s: PipelineRun fournos-%s not found", name, name)
         return
@@ -226,13 +339,44 @@ def _reconcile_running(name, patch):
     )
     if pr_status == "succeeded":
         patch.status["phase"] = "Succeeded"
+        patch.status["message"] = "Pipeline completed successfully"
+        _set_condition(
+            patch,
+            conditions,
+            COND_PIPELINE_RUN_READY,
+            "True",
+            "Succeeded",
+            pr_message or "Pipeline completed successfully",
+        )
         _kueue.delete_workload(name)
         logger.info("Job %s: succeeded", name)
     elif pr_status == "failed":
         patch.status["phase"] = "Failed"
         patch.status["message"] = pr_message or "PipelineRun failed"
+        _set_condition(
+            patch,
+            conditions,
+            COND_PIPELINE_RUN_READY,
+            "False",
+            "Failed",
+            pr_message or "PipelineRun failed",
+        )
         _kueue.delete_workload(name)
         logger.warning("Job %s: PipelineRun failed: %s", name, pr_message)
+    else:
+        new_msg = (
+            f"Pipeline running: {pr_message}" if pr_message else "Pipeline running"
+        )
+        if status.get("message") != new_msg:
+            patch.status["message"] = new_msg
+            _set_condition(
+                patch,
+                conditions,
+                COND_PIPELINE_RUN_READY,
+                "Unknown",
+                "Running",
+                pr_message or "PipelineRun is executing",
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -34,6 +34,9 @@ spec:
         - name: Cluster
           type: string
           jsonPath: .status.cluster
+        - name: Message
+          type: string
+          jsonPath: .status.message
         - name: Age
           type: date
           jsonPath: .metadata.creationTimestamp

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,11 +127,40 @@ def poll_phase(
             break
         time.sleep(interval)
     if raise_on_timeout:
+        job = get_job(k8s, name)
+        status = job.get("status", {})
+        detail = f"phase={phase or '<unset>'}"
+        if status.get("message"):
+            detail += f", message={status['message']!r}"
+        for c in status.get("conditions", []):
+            cond_str = f"{c['type']}={c['status']}"
+            if c.get("reason"):
+                cond_str += f" ({c['reason']})"
+            if c.get("message"):
+                cond_str += f": {c['message']}"
+            detail += f"\n    {cond_str}"
         raise AssertionError(
-            f"Job {name} did not reach {terminal} within {timeout}s "
-            f"(last phase: {phase})"
+            f"Job {name} did not reach {terminal} within {timeout}s.\n"
+            f"  Current status: {detail}"
         )
     return phase
+
+
+def job_status_summary(k8s, name: str) -> str:
+    """Return a one-line status summary for use in assertion messages."""
+    job = get_job(k8s, name)
+    st = job.get("status", {})
+    parts = [f"phase={st.get('phase', '<unset>')!r}"]
+    if st.get("message"):
+        parts.append(f"message={st['message']!r}")
+    if st.get("cluster"):
+        parts.append(f"cluster={st['cluster']!r}")
+    for c in st.get("conditions", []):
+        cond_str = f"{c['type']}={c['status']}"
+        if c.get("reason"):
+            cond_str += f"/{c['reason']}"
+        parts.append(cond_str)
+    return f"Job {name}: {', '.join(parts)}"
 
 
 def workload_exists(name: str) -> bool:
@@ -165,7 +194,9 @@ def poll_resource_gone(
         if not check_fn(name):
             return
         time.sleep(interval)
-    raise AssertionError(f"Resource for {name} still exists after {timeout}s")
+    raise AssertionError(
+        f"{check_fn.__name__}({name!r}): resource still exists after {timeout}s"
+    )
 
 
 def get_k8s_resource(kind: str, name: str) -> dict:

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -8,6 +8,8 @@ from tests.conftest import (
     PLURAL,
     VERSION,
     create_job,
+    get_job,
+    job_status_summary,
     pipelinerun_exists,
     poll_phase,
     poll_resource_gone,
@@ -32,7 +34,23 @@ def test_workload_cleaned_after_completion(k8s):
         terminal={"Succeeded", "Failed"},
         timeout=60,
     )
-    assert phase == "Succeeded"
+    assert phase == "Succeeded", job_status_summary(k8s, "test-wl-cleanup")
+
+    job = get_job(k8s, "test-wl-cleanup")
+    conditions = {c["type"]: c for c in job["status"].get("conditions", [])}
+    assert "WorkloadAdmitted" in conditions, (
+        f"Missing WorkloadAdmitted condition; got {list(conditions)}"
+    )
+    assert conditions["WorkloadAdmitted"]["status"] == "True", (
+        f"WorkloadAdmitted should be True; got {conditions['WorkloadAdmitted']}"
+    )
+    assert "PipelineRunReady" in conditions, (
+        f"Missing PipelineRunReady condition; got {list(conditions)}"
+    )
+    assert conditions["PipelineRunReady"]["status"] == "True", (
+        f"PipelineRunReady should be True; got {conditions['PipelineRunReady']}"
+    )
+    assert job["status"].get("message"), "Succeeded job should have a status message"
 
     poll_resource_gone(workload_exists, "test-wl-cleanup")
 
@@ -54,7 +72,9 @@ def test_delete_cleans_up_resources(k8s):
         terminal={"Running", "Succeeded", "Failed"},
         timeout=30,
     )
-    assert pipelinerun_exists("test-delete")
+    assert pipelinerun_exists("test-delete"), (
+        "PipelineRun fournos-test-delete should exist before job deletion"
+    )
 
     k8s.delete_namespaced_custom_object(
         GROUP,
@@ -89,9 +109,11 @@ def test_list_multiple_jobs(k8s):
 
     jobs = k8s.list_namespaced_custom_object(GROUP, VERSION, NAMESPACE, PLURAL)
     names = {j["metadata"]["name"] for j in jobs["items"]}
-    assert "test-list-a" in names
-    assert "test-list-b" in names
-    assert len(jobs["items"]) == 2
+    assert "test-list-a" in names, f"test-list-a not found in {names}"
+    assert "test-list-b" in names, f"test-list-b not found in {names}"
+    assert len(jobs["items"]) == 2, (
+        f"Expected exactly 2 jobs, found {len(jobs['items'])}: {names}"
+    )
 
 
 def test_filter_jobs_by_phase(k8s):
@@ -126,5 +148,9 @@ def test_filter_jobs_by_phase(k8s):
         j["metadata"]["name"]: j.get("status", {}).get("phase", "")
         for j in jobs["items"]
     }
-    assert phases["test-filter-stuck"] == "Pending"
-    assert phases["test-filter-ok"] in ("Admitted", "Running", "Succeeded")
+    assert phases["test-filter-stuck"] == "Pending", (
+        f"Stuck job should remain Pending, got {phases['test-filter-stuck']!r}"
+    )
+    assert phases["test-filter-ok"] in ("Admitted", "Running", "Succeeded"), (
+        f"OK job should have progressed past Pending, got {phases['test-filter-ok']!r}"
+    )

--- a/tests/test_resource_gc.py
+++ b/tests/test_resource_gc.py
@@ -18,7 +18,9 @@ from tests.conftest import (
 def test_stale_workload_collected(k8s):
     """A fournos-labeled Workload with no parent FournosJob is deleted by GC."""
     create_stale_workload(k8s, "stale-wl")
-    assert workload_exists("stale-wl")
+    assert workload_exists("stale-wl"), (
+        "Stale Workload fournos-stale-wl should exist after creation"
+    )
 
     poll_resource_gone(workload_exists, "stale-wl", timeout=60)
 
@@ -26,6 +28,8 @@ def test_stale_workload_collected(k8s):
 def test_stale_pipelinerun_collected(k8s):
     """A fournos-labeled PipelineRun with no parent FournosJob is deleted by GC."""
     create_stale_pipelinerun(k8s, "stale-pr")
-    assert pipelinerun_exists("stale-pr")
+    assert pipelinerun_exists("stale-pr"), (
+        "Stale PipelineRun fournos-stale-pr should exist after creation"
+    )
 
     poll_resource_gone(pipelinerun_exists, "stale-pr", timeout=60)

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -9,6 +9,7 @@ from tests.conftest import (
     get_pipelinerun_param,
     get_workload_flavor,
     get_workload_node_selector,
+    job_status_summary,
     poll_phase,
     workload_exists,
 )
@@ -34,13 +35,15 @@ def test_cluster_pinned(k8s):
         timeout=30,
     )
 
-    assert get_workload_node_selector("test-cluster") == {
-        "fournos.dev/cluster": "cluster-2",
-    }
-    assert get_workload_flavor("test-cluster") == "cluster-2"
-    assert (
-        get_pipelinerun_param("test-cluster", "kubeconfig-secret")
-        == "cluster-2-kubeconfig"
+    ns = get_workload_node_selector("test-cluster")
+    assert ns == {"fournos.dev/cluster": "cluster-2"}, (
+        f"Workload nodeSelector should pin to cluster-2, got {ns}"
+    )
+    flavor = get_workload_flavor("test-cluster")
+    assert flavor == "cluster-2", f"Workload flavor should be cluster-2, got {flavor!r}"
+    secret = get_pipelinerun_param("test-cluster", "kubeconfig-secret")
+    assert secret == "cluster-2-kubeconfig", (
+        f"PipelineRun kubeconfig-secret should be cluster-2-kubeconfig, got {secret!r}"
     )
 
     phase = poll_phase(
@@ -49,10 +52,12 @@ def test_cluster_pinned(k8s):
         terminal={"Succeeded", "Failed"},
         timeout=60,
     )
-    assert phase == "Succeeded"
+    assert phase == "Succeeded", job_status_summary(k8s, "test-cluster")
 
     job = get_job(k8s, "test-cluster")
-    assert job["status"]["cluster"] == "cluster-2"
+    assert job["status"]["cluster"] == "cluster-2", (
+        f"Expected cluster cluster-2, got {job['status'].get('cluster')!r}"
+    )
 
 
 def test_hardware_request(k8s):
@@ -73,10 +78,13 @@ def test_hardware_request(k8s):
         terminal={"Succeeded", "Failed"},
         timeout=60,
     )
-    assert phase == "Succeeded"
+    assert phase == "Succeeded", job_status_summary(k8s, "test-hardware")
 
     job = get_job(k8s, "test-hardware")
-    assert job["status"].get("cluster") in ("cluster-1", "cluster-2")
+    cluster = job["status"].get("cluster")
+    assert cluster in ("cluster-1", "cluster-2"), (
+        f"Expected cluster-1 or cluster-2, got {cluster!r}"
+    )
 
 
 def test_cluster_and_hardware(k8s):
@@ -99,13 +107,15 @@ def test_cluster_and_hardware(k8s):
         timeout=30,
     )
 
-    assert get_workload_node_selector("test-cluster-hw") == {
-        "fournos.dev/cluster": "cluster-4",
-    }
-    assert get_workload_flavor("test-cluster-hw") == "cluster-4"
-    assert (
-        get_pipelinerun_param("test-cluster-hw", "kubeconfig-secret")
-        == "cluster-4-kubeconfig"
+    ns = get_workload_node_selector("test-cluster-hw")
+    assert ns == {"fournos.dev/cluster": "cluster-4"}, (
+        f"Workload nodeSelector should pin to cluster-4, got {ns}"
+    )
+    flavor = get_workload_flavor("test-cluster-hw")
+    assert flavor == "cluster-4", f"Workload flavor should be cluster-4, got {flavor!r}"
+    secret = get_pipelinerun_param("test-cluster-hw", "kubeconfig-secret")
+    assert secret == "cluster-4-kubeconfig", (
+        f"PipelineRun kubeconfig-secret should be cluster-4-kubeconfig, got {secret!r}"
     )
 
     phase = poll_phase(
@@ -114,10 +124,12 @@ def test_cluster_and_hardware(k8s):
         terminal={"Succeeded", "Failed"},
         timeout=60,
     )
-    assert phase == "Succeeded"
+    assert phase == "Succeeded", job_status_summary(k8s, "test-cluster-hw")
 
     job = get_job(k8s, "test-cluster-hw")
-    assert job["status"]["cluster"] == "cluster-4"
+    assert job["status"]["cluster"] == "cluster-4", (
+        f"Expected cluster cluster-4, got {job['status'].get('cluster')!r}"
+    )
 
 
 def test_alternative_pipeline_selection(k8s):
@@ -138,14 +150,17 @@ def test_alternative_pipeline_selection(k8s):
         terminal={"Succeeded", "Failed"},
         timeout=60,
     )
-    assert phase == "Succeeded"
+    assert phase == "Succeeded", job_status_summary(k8s, "test-run-only")
 
     pr = get_k8s_resource("pipelinerun", "fournos-test-run-only")
-    assert pr["spec"]["pipelineRef"]["name"] == "fournos-run-only"
+    pipeline_ref = pr["spec"]["pipelineRef"]["name"]
+    assert pipeline_ref == "fournos-run-only", (
+        f"PipelineRun should reference fournos-run-only, got {pipeline_ref!r}"
+    )
 
 
 def test_inadmissible_stays_pending(k8s):
-    """Hardware request exceeding all cluster quotas stays Pending."""
+    """Hardware request exceeding all cluster quotas stays Pending with admission detail."""
     create_job(
         k8s,
         "test-inadmissible",
@@ -163,8 +178,28 @@ def test_inadmissible_stays_pending(k8s):
         timeout=15,
         raise_on_timeout=False,
     )
-    assert phase == "Pending"
-    assert workload_exists("test-inadmissible")
+    assert phase == "Pending", f"Inadmissible job should stay Pending, got {phase!r}"
+    assert workload_exists("test-inadmissible"), (
+        "Workload fournos-test-inadmissible should still exist"
+    )
+
+    job = get_job(k8s, "test-inadmissible")
+    assert job["status"].get("message"), (
+        "Pending job should have a status message explaining the admission state"
+    )
+
+    conditions = job["status"].get("conditions", [])
+    wl_cond = next(
+        (c for c in conditions if c["type"] == "WorkloadAdmitted"),
+        None,
+    )
+    assert wl_cond is not None, (
+        f"Pending job should have a WorkloadAdmitted condition; got types: "
+        f"{[c['type'] for c in conditions]}"
+    )
+    assert wl_cond["status"] == "False", (
+        f"WorkloadAdmitted should be False for inadmissible job; got {wl_cond}"
+    )
 
 
 def test_cluster_without_required_gpu_stays_pending(k8s):
@@ -187,7 +222,9 @@ def test_cluster_without_required_gpu_stays_pending(k8s):
         timeout=15,
         raise_on_timeout=False,
     )
-    assert phase == "Pending"
+    assert phase == "Pending", (
+        f"Job requesting A100s on cluster-3 should stay Pending, got {phase!r}"
+    )
 
 
 def test_optional_spec_fields(k8s):
@@ -212,7 +249,9 @@ def test_optional_spec_fields(k8s):
     )
 
     job = get_job(k8s, "test-opts")
-    assert job["spec"]["owner"] == "perf-team"
+    assert job["spec"]["owner"] == "perf-team", (
+        f"Owner should be perf-team, got {job['spec'].get('owner')!r}"
+    )
 
     poll_phase(
         k8s,
@@ -221,9 +260,17 @@ def test_optional_spec_fields(k8s):
         timeout=30,
     )
 
-    assert get_pipelinerun_param("test-opts", "job-name") == "nightly-llama3-benchmark"
-    assert (
-        json.loads(get_pipelinerun_param("test-opts", "forge-config-overrides"))
-        == overrides
+    job_name_param = get_pipelinerun_param("test-opts", "job-name")
+    assert job_name_param == "nightly-llama3-benchmark", (
+        f"PipelineRun job-name param should be the displayName, got {job_name_param!r}"
     )
-    assert json.loads(get_pipelinerun_param("test-opts", "env")) == env
+
+    config_overrides = json.loads(
+        get_pipelinerun_param("test-opts", "forge-config-overrides")
+    )
+    assert config_overrides == overrides, (
+        f"forge-config-overrides mismatch: {config_overrides}"
+    )
+
+    env_param = json.loads(get_pipelinerun_param("test-opts", "env"))
+    assert env_param == env, f"env param mismatch: {env_param}"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -7,6 +7,7 @@ from tests.conftest import (
     NAMESPACE,
     create_job,
     get_job,
+    job_status_summary,
     poll_phase,
     poll_resource_gone,
     workload_exists,
@@ -29,11 +30,13 @@ def test_neither_cluster_nor_hardware(k8s):
         terminal={"Failed"},
         timeout=15,
     )
-    assert phase == "Failed"
+    assert phase == "Failed", job_status_summary(k8s, "test-no-target")
 
     job = get_job(k8s, "test-no-target")
     msg = job["status"]["message"].lower()
-    assert "cluster" in msg or "hardware" in msg
+    assert "cluster" in msg or "hardware" in msg, (
+        f"Failure message should mention 'cluster' or 'hardware', got: {msg!r}"
+    )
 
 
 def test_unknown_cluster(k8s):
@@ -53,10 +56,13 @@ def test_unknown_cluster(k8s):
         terminal={"Failed"},
         timeout=15,
     )
-    assert phase == "Failed"
+    assert phase == "Failed", job_status_summary(k8s, "test-unknown")
 
     job = get_job(k8s, "test-unknown")
-    assert "not found" in job["status"]["message"].lower()
+    msg = job["status"]["message"].lower()
+    assert "not found" in msg, (
+        f"Failure message should mention 'not found', got: {msg!r}"
+    )
 
 
 def test_unknown_gpu_type(k8s):
@@ -76,12 +82,16 @@ def test_unknown_gpu_type(k8s):
         terminal={"Failed"},
         timeout=15,
     )
-    assert phase == "Failed"
+    assert phase == "Failed", job_status_summary(k8s, "test-bad-gpu")
 
     job = get_job(k8s, "test-bad-gpu")
     msg = job["status"]["message"]
-    assert "acbd1234" in msg.lower()
-    assert "not available" in msg.lower()
+    assert "acbd1234" in msg.lower(), (
+        f"Failure message should mention the GPU type 'acbd1234', got: {msg!r}"
+    )
+    assert "not available" in msg.lower(), (
+        f"Failure message should say 'not available', got: {msg!r}"
+    )
 
 
 def test_admitted_without_flavor(k8s):
@@ -135,8 +145,24 @@ def test_admitted_without_flavor(k8s):
         terminal={"Failed"},
         timeout=30,
     )
-    assert phase == "Failed"
+    assert phase == "Failed", job_status_summary(k8s, "test-no-flavor")
 
     job = get_job(k8s, "test-no-flavor")
-    assert "no flavor" in job["status"]["message"].lower()
+    msg = job["status"]["message"].lower()
+    assert "no flavor" in msg, (
+        f"Failure message should mention 'no flavor', got: {msg!r}"
+    )
+
+    conditions = {c["type"]: c for c in job["status"].get("conditions", [])}
+    assert "WorkloadAdmitted" in conditions, (
+        f"Missing WorkloadAdmitted condition; got types: {list(conditions)}"
+    )
+    assert conditions["WorkloadAdmitted"]["status"] == "False", (
+        f"WorkloadAdmitted should be False; got {conditions['WorkloadAdmitted']}"
+    )
+    assert conditions["WorkloadAdmitted"]["reason"] == "NoFlavorAssigned", (
+        f"WorkloadAdmitted reason should be NoFlavorAssigned; "
+        f"got {conditions['WorkloadAdmitted'].get('reason')!r}"
+    )
+
     poll_resource_gone(workload_exists, "test-no-flavor")


### PR DESCRIPTION
The FournosJob status was opaque: a Pending job gave no indication of why it wasn't progressing (e.g. missing LocalQueue, namespace mismatch), and PipelineRun failures were only surfaced once terminal.

Now the operator propagates child-resource conditions throughout the lifecycle:
- `Pending`: Kueue Workload conditions (reason + message) are mirrored into status.message and a WorkloadAdmitted condition.
- `Admitted` → `Running`: a PipelineRunReady condition tracks creation and intermediate pipeline status.
- `Terminal`: both conditions reflect the final outcome.

The CRD gains a Message printer column so `oc get fjobs` shows the reason at a glance, e.g.:
```
oc get fjobs -n psap-automation 
NAME             OWNER   PHASE    CLUSTER   MESSAGE                                    AGE
test-no-flavor           Failed             Workload admitted but no flavor assigned   11m
```

Improved tests to include descriptive failure messages and poll_phase dumps full job status on timeout.

Closes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added status messages to jobs that provide detailed context about current state and any pending conditions.
  * Added "Message" column to kubectl output for improved visibility into job status.
  * Enhanced condition tracking with WorkloadAdmitted and PipelineRunReady status indicators.

* **Tests**
  * Improved test diagnostics with richer assertion messages for better failure context and debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->