### PR TITLE
Simplify Fournos namespace config

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -6,6 +6,7 @@ on:
 env:
   KIND_CLUSTER_NAME: fournos-ci
   KIND_EXPERIMENTAL_PROVIDER: docker
+  FOURNOS_NAMESPACE: psap-automation-ci-test
 
 jobs:
   integration:

--- a/Containerfile
+++ b/Containerfile
@@ -15,4 +15,4 @@ RUN pip install --no-cache-dir --no-deps .
 
 USER 1001
 
-ENTRYPOINT ["kopf", "run", "-m", "fournos.operator", "--liveness=http://0.0.0.0:8080/healthz"]
+ENTRYPOINT ["python", "-m", "fournos", "--liveness=http://0.0.0.0:8080/healthz"]

--- a/Makefile
+++ b/Makefile
@@ -38,17 +38,18 @@ deploy: install
 ##@ Testing
 
 test:
-	$(VENV_BIN)pytest -v tests/
+	FOURNOS_NAMESPACE=$(or $(FOURNOS_NAMESPACE),fournos-local-dev) $(VENV_BIN)pytest -v tests/
 
 ##@ Local Development
 
 dev-setup:
 	@KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
 	 KIND_EXPERIMENTAL_PROVIDER=$(KIND_EXPERIMENTAL_PROVIDER) \
+	 FOURNOS_NAMESPACE=$(or $(FOURNOS_NAMESPACE),fournos-local-dev) \
 	 bash dev/setup.sh
 
 dev-run:
-	FOURNOS_GC_INTERVAL_SEC=5 $(VENV_BIN)kopf run -m fournos.operator --namespace $(FOURNOS_NAMESPACE)
+	FOURNOS_GC_INTERVAL_SEC=5 FOURNOS_NAMESPACE=$(or $(FOURNOS_NAMESPACE),fournos-local-dev) $(VENV_BIN)python -m fournos
 
 dev-teardown:
 	KIND_EXPERIMENTAL_PROVIDER=$(KIND_EXPERIMENTAL_PROVIDER) kind delete cluster --name $(KIND_CLUSTER_NAME)
@@ -58,11 +59,12 @@ dev-teardown:
 ci-setup:
 	@KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
 	 KIND_EXPERIMENTAL_PROVIDER=docker \
+	 FOURNOS_NAMESPACE=$(or $(FOURNOS_NAMESPACE),psap-automation-ci-test) \
 	 bash dev/setup.sh
 
 ci-run:
-	FOURNOS_GC_INTERVAL_SEC=5 \
-	  $(VENV_BIN)kopf run -m fournos.operator \
+	FOURNOS_GC_INTERVAL_SEC=5 FOURNOS_NAMESPACE=$(or $(FOURNOS_NAMESPACE),psap-automation-ci-test) \
+	  $(VENV_BIN)python -m fournos \
 	  --liveness=http://0.0.0.0:8080/healthz > fournos.log 2>&1 & \
 	echo $$! > fournos.pid; \
 	echo "Waiting for operator to be ready..."; \

--- a/README.md
+++ b/README.md
@@ -101,16 +101,17 @@ Prerequisites: [Podman](https://podman.io/),
 [kind](https://kind.sigs.k8s.io/), and `kubectl`.
 
 ```bash
-oc new-project fournos-$USER-dev
 make dev-setup    # creates a kind cluster, installs Tekton + Kueue + CRD, applies mock resources
-export FOURNOS_NAMESPACE=$(oc project -q)
 make dev-run      # starts the operator locally (connects to the kind cluster)
 ```
+
+Both targets default to the `fournos-local-dev` namespace. Override with
+`FOURNOS_NAMESPACE=<YOUR_NAMESPACE> make dev-setup dev-run`.
 
 In another terminal:
 
 ```bash
-make test                              # run the integration test suite
+FOURNOS_NAMESPACE=fournos-local-dev make test   # run the integration test suite
 ```
 
 ```bash
@@ -205,7 +206,7 @@ All settings are read from environment variables with the `FOURNOS_` prefix:
 
 | Variable | Default | Description |
 |---|---|---|
-| `FOURNOS_NAMESPACE` | `fournos-$USER-dev` | Kubernetes namespace |
+| `FOURNOS_NAMESPACE` | **required** | Kubernetes namespace |
 | `FOURNOS_TEKTON_DASHBOARD_URL` | | Tekton Dashboard base URL |
 | `FOURNOS_KUBECONFIG_SECRET_PATTERN` | `{cluster}-kubeconfig` | Pattern for resolving cluster names to Secret names |
 | `FOURNOS_KUEUE_LOCAL_QUEUE_NAME` | `fournos-queue` | Kueue LocalQueue name |

--- a/dev/sample-job.yaml
+++ b/dev/sample-job.yaml
@@ -2,7 +2,6 @@ apiVersion: fournos.dev/v1
 kind: FournosJob
 metadata:
   generateName: test-job-
-  namespace: psap-automation
 spec:
   owner: perf-team
   displayName: sample-benchmark

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -65,7 +65,7 @@ done
 # Prepare the namespace
 # ---------------------
 
-FOURNOS_NAMESPACE=psap-automation
+: "${FOURNOS_NAMESPACE:?FOURNOS_NAMESPACE must be set}"
 kubectl create ns "$FOURNOS_NAMESPACE" --dry-run -oyaml | kubectl apply -f-
 kubectl label ns/$FOURNOS_NAMESPACE fournos.dev/queue-access=true
 

--- a/fournos/__main__.py
+++ b/fournos/__main__.py
@@ -1,0 +1,24 @@
+"""Entry point: bridges FOURNOS_NAMESPACE env var to kopf --namespace."""
+
+import os
+import sys
+
+ns = os.environ.get("FOURNOS_NAMESPACE")
+if not ns:
+    print("ERROR: FOURNOS_NAMESPACE env var is required", file=sys.stderr)
+    sys.exit(1)
+
+# Build the kopf CLI invocation, forwarding any extra args (e.g. --liveness)
+sys.argv = [
+    "kopf",
+    "run",
+    "-m",
+    "fournos.operator",
+    "--namespace",
+    ns,
+    *sys.argv[1:],
+]
+
+from kopf.cli import main  # noqa: E402
+
+main()

--- a/fournos/operator.py
+++ b/fournos/operator.py
@@ -81,6 +81,8 @@ def startup(**_):
     _tekton = TektonClient(custom_objects)
     _registry = ClusterRegistry(client.CoreV1Api())
 
+    logger.info("Operating in namespace %s", settings.namespace)
+
     gc_thread = threading.Thread(target=_gc_loop, daemon=True)
     gc_thread.start()
     logger.info("Resource GC started (interval=%ss)", settings.gc_interval_sec)

--- a/fournos/settings.py
+++ b/fournos/settings.py
@@ -5,7 +5,7 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     model_config = {"env_prefix": "FOURNOS_"}
 
-    namespace: str = "psap-automation"
+    namespace: str = Field(description="Kubernetes namespace (FOURNOS_NAMESPACE)")
     tekton_dashboard_url: str = ""
     kubeconfig_secret_pattern: str = "{cluster}-kubeconfig"
     kueue_local_queue_name: str = "fournos-queue"

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -18,7 +18,6 @@ spec:
       containers:
         - name: fournos
           image: quay.io/rh_perfscale/fournos:latest
-          args: ["--namespace=$(FOURNOS_NAMESPACE)"]
           env:
             - name: FOURNOS_NAMESPACE
               valueFrom:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 import textwrap
 import time
@@ -10,7 +9,9 @@ from typing import Any
 import pytest
 from kubernetes import client, config
 
-NAMESPACE = os.environ.get("FOURNOS_NAMESPACE", "psap-automation")
+from fournos.settings import settings
+
+NAMESPACE = settings.namespace
 GROUP = "fournos.dev"
 VERSION = "v1"
 PLURAL = "fournosjobs"


### PR DESCRIPTION
This PR simplifies namespace configuration for Fournos:
* Only FOURNOS_NAMESPACE envvar is now required, the --namespace argumentfor kopf is derived from it.
* Introduce separate namespaces for local dev environment and CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Namespace configuration now enforced as a required environment variable (`FOURNOS_NAMESPACE`) across all environments.

* **Documentation**
  * Updated setup and testing instructions to reflect namespace configuration requirements and defaults.

* **Chores**
  * Refined operator initialization and namespace handling across development, testing, and CI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->