### PR TITLE
Improve lifecycle by introducing ownership; improve dependent resources labeling

### DIFF
--- a/.cursor/plans/fournos_design_document_87fc6306.plan.md
+++ b/.cursor/plans/fournos_design_document_87fc6306.plan.md
@@ -9,7 +9,7 @@ todos:
     content: "FournosJob CRD: spec (forge, cluster, hardware, pipeline, priority, secretRefs, env) and status (phase, cluster, pipelineRun, dashboardURL, message)"
     status: complete
   - id: 3-operator
-    content: "kopf operator: startup handler, on_create/on_resume handler (validate, create Workload), timer handler (state machine: Pending→Admitted→Running→terminal), on_delete handler (cleanup)"
+    content: "kopf operator: startup handler, on_create/on_resume handler (validate, create Workload), timer handler (state machine: Pending→Admitted→Running→terminal), ownerReferences for cascade deletion"
     status: complete
   - id: 4-core-clusters
     content: "core/clusters.py: ClusterRegistry — resolve kubeconfig Secrets, check cluster existence"
@@ -194,11 +194,12 @@ sequenceDiagram
 
 
 
-1. **on_create**: Operator validates the spec (cluster exists, at least one of cluster/hardware), creates a Kueue Workload, sets `phase=Pending`
+1. **on_create**: Operator validates the spec (cluster exists, at least one of cluster/hardware), creates a Kueue Workload with `ownerReferences` pointing at the FournosJob, sets `phase=Pending`
 2. **timer (Pending)**: Polls the Workload for Kueue admission. On admission, reads the assigned flavor (= cluster name), sets `phase=Admitted`
-3. **timer (Admitted)**: Resolves the kubeconfig Secret, creates the Tekton PipelineRun, sets `phase=Running`
+3. **timer (Admitted)**: Resolves the kubeconfig Secret, creates the Tekton PipelineRun with `ownerReferences` pointing at the FournosJob, sets `phase=Running`
 4. **timer (Running)**: Polls the PipelineRun for completion. On success/failure, deletes the Workload and sets `phase=Succeeded` or `phase=Failed`
-5. **on_delete**: Cleans up associated Workload and PipelineRun
+
+Deleting a FournosJob triggers Kubernetes cascade deletion of its owned Workload and PipelineRun via `ownerReferences` — no explicit cleanup handler is needed.
 
 Benefits of the unified path:
 
@@ -215,9 +216,8 @@ The operator is implemented in `fournos/operator.py` using [kopf](https://kopf.d
 | Handler                               | Trigger                                             | Responsibility                                                               |
 | ------------------------------------- | --------------------------------------------------- | ---------------------------------------------------------------------------- |
 | `@kopf.on.startup`                    | Process start                                       | Load kubeconfig, initialise clients, start resource GC thread                |
-| `@kopf.on.create` / `@kopf.on.resume` | New or existing CR                                  | Validate spec, create Workload, set `phase=Pending`                          |
-| `@kopf.timer(interval=5.0)`           | Every 5s while phase ∈ {Pending, Admitted, Running} | Drive the state machine: poll admission, create PipelineRun, poll completion |
-| `@kopf.on.delete`                     | CR deletion                                         | Delete associated Workload and PipelineRun                                   |
+| `@kopf.on.create` / `@kopf.on.resume` | New or existing CR                                  | Validate spec, create Workload (with ownerRef), set `phase=Pending`          |
+| `@kopf.timer(interval=5.0)`           | Every 5s while phase ∈ {Pending, Admitted, Running} | Drive the state machine: poll admission, create PipelineRun (with ownerRef), poll completion |
 
 
 The timer's `when` guard ensures it stops firing once the job reaches a terminal phase (`Succeeded` or `Failed`), so completed jobs have zero ongoing overhead.
@@ -226,7 +226,7 @@ Validation failures (unknown cluster, missing cluster/hardware) result in immedi
 
 ### Resource GC
 
-A background daemon thread runs a garbage collection loop at a configurable interval (`FOURNOS_GC_INTERVAL_SEC`, default 300s). It lists all fournos-managed Workloads and PipelineRuns (by label `app.kubernetes.io/managed-by=fournos`), reads the `fournos.dev/job-name` label on each, and deletes any whose parent `FournosJob` CR no longer exists. This handles edge cases where the operator's `on_delete` handler fails or a CR is force-deleted.
+A background daemon thread runs a garbage collection loop at a configurable interval (`FOURNOS_GC_INTERVAL_SEC`, default 300s). It lists all fournos-managed Workloads and PipelineRuns (by label `app.kubernetes.io/managed-by=fournos`), reads the `fournos.dev/job-name` label on each, and deletes any whose parent `FournosJob` CR no longer exists. This serves as a safety net for resources that somehow lost their `ownerReferences` (e.g. created before ownership was added, or manually recreated).
 
 ## 6. Persistence
 
@@ -326,7 +326,7 @@ All settings via environment variables with `FOURNOS_` prefix ([fournos/settings
 
 ```
 fournos/
-  operator.py              # kopf operator (startup, create/resume, timer, delete handlers)
+  operator.py              # kopf operator (startup, create/resume, timer handlers)
   settings.py              # Pydantic Settings (env vars)
   core/
     constants.py           # Shared label keys
@@ -367,6 +367,7 @@ README.md
 - **Stateless operator** — all job state lives in Kubernetes resources (FournosJob CRs, PipelineRuns, Workloads), not in memory. Crash-safe via `on_resume`.
 - **Timer-based reconciliation** — the operator polls Workload admission and PipelineRun completion via a kopf timer (5s interval), eliminating the need for callback tasks or watch streams on third-party resources
 - **Operator cleans up on completion** — Kueue Workloads are deleted when the PipelineRun reaches a terminal state, releasing quota without relying on external callbacks
+- **ownerReferences for cascade deletion** — Workloads and PipelineRuns carry `ownerReferences` pointing at their FournosJob, so Kubernetes automatically cascade-deletes them when the job is removed
 - **Multiple pipelines** — `fournos-full` (prepare → run → cleanup) and `fournos-run-only` (run only), selectable per job
 - **Target clusters need nothing installed** — FORGE runs on the hub cluster inside Tekton Task pods and communicates with targets via remote `oc`/`kubectl` commands through kubeconfig Secrets
 

--- a/README.md
+++ b/README.md
@@ -228,11 +228,14 @@ FournosJob CR ──→ Operator ──→ Kueue Workload ──→ (admission) 
 The operator runs as a single-replica Deployment using
 [kopf](https://kopf.dev/). On each `FournosJob`, it:
 
-1. **Creates** a Kueue Workload with the requested GPU resources
+1. **Creates** a Kueue Workload with the requested GPU resources (owned by the FournosJob via `ownerReferences`)
 2. **Polls** (5 s timer) for Kueue admission and assigned cluster
-3. **Launches** a Tekton PipelineRun with FORGE parameters
+3. **Launches** a Tekton PipelineRun with FORGE parameters (owned by the FournosJob via `ownerReferences`)
 4. **Watches** the PipelineRun until completion
 5. **Deletes** the Workload to release Kueue quota
+
+Deleting a FournosJob automatically cascade-deletes its Workload and
+PipelineRun through Kubernetes owner references.
 
 Target clusters need nothing installed — FORGE runs on the hub cluster inside
 Tekton Task pods and communicates with targets via `oc`/`kubectl` through

--- a/fournos/core/kueue.py
+++ b/fournos/core/kueue.py
@@ -32,9 +32,8 @@ class KueueClient:
         gpu_count: int = 0,
         cluster: str | None = None,
         priority: str | None = None,
+        owner_ref: dict | None = None,
     ) -> dict:
-        workload_name = f"fournos-{name}"
-
         resource_requests: dict[str, str] = {"cpu": "1"}
         if gpu_type and gpu_count:
             gpu_resource = self._gpu_resource_name(gpu_type)
@@ -54,18 +53,22 @@ class KueueClient:
         if cluster:
             pod_spec["nodeSelector"] = {"fournos.dev/cluster": cluster}
 
+        metadata: dict = {
+            "name": name,
+            "namespace": settings.namespace,
+            "labels": {
+                "kueue.x-k8s.io/queue-name": settings.kueue_local_queue_name,
+                LABEL_MANAGED_BY: "fournos",
+                LABEL_JOB_NAME: name,
+            },
+        }
+        if owner_ref:
+            metadata["ownerReferences"] = [owner_ref]
+
         body: dict = {
             "apiVersion": f"{KUEUE_GROUP}/{KUEUE_VERSION}",
             "kind": "Workload",
-            "metadata": {
-                "name": workload_name,
-                "namespace": settings.namespace,
-                "labels": {
-                    "kueue.x-k8s.io/queue-name": settings.kueue_local_queue_name,
-                    LABEL_MANAGED_BY: "fournos",
-                    LABEL_JOB_NAME: name,
-                },
-            },
+            "metadata": metadata,
             "spec": {
                 "queueName": settings.kueue_local_queue_name,
                 "podSets": [
@@ -88,7 +91,7 @@ class KueueClient:
             plural=KUEUE_WORKLOAD_PLURAL,
             body=body,
         )
-        logger.info("Created Kueue Workload %s for job %s", workload_name, name)
+        logger.info("Created Kueue Workload %s", name)
         return result
 
     def get_workload(self, name: str) -> dict:
@@ -97,7 +100,7 @@ class KueueClient:
             version=KUEUE_VERSION,
             namespace=settings.namespace,
             plural=KUEUE_WORKLOAD_PLURAL,
-            name=f"fournos-{name}",
+            name=name,
         )
 
     def get_workload_or_none(self, name: str) -> dict | None:
@@ -174,16 +177,15 @@ class KueueClient:
 
     def delete_workload(self, name: str) -> None:
         """Delete the virtual Workload to release Kueue quota."""
-        workload_name = f"fournos-{name}"
         try:
             self._k8s.delete_namespaced_custom_object(
                 group=KUEUE_GROUP,
                 version=KUEUE_VERSION,
                 namespace=settings.namespace,
                 plural=KUEUE_WORKLOAD_PLURAL,
-                name=workload_name,
+                name=name,
             )
-            logger.info("Deleted Kueue Workload %s", workload_name)
+            logger.info("Deleted Kueue Workload %s", name)
         except client.exceptions.ApiException as exc:
             if exc.status != 404:
                 raise

--- a/fournos/core/tekton.py
+++ b/fournos/core/tekton.py
@@ -37,24 +37,34 @@ class TektonClient:
         gpu_count: int,
         secret_refs: list[str],
         cluster: str,
+        owner_ref: dict | None = None,
     ) -> dict:
-        pipeline_run_name = f"fournos-{name}"
+        labels = {
+            LABEL_MANAGED_BY: "fournos",
+            LABEL_JOB_NAME: name,
+        }
+        metadata: dict = {
+            "name": name,
+            "namespace": settings.namespace,
+            "labels": labels,
+            "annotations": {
+                "fournos.dev/cluster": cluster,
+            },
+        }
+        if owner_ref:
+            metadata["ownerReferences"] = [owner_ref]
+
         body = {
             "apiVersion": f"{TEKTON_GROUP}/{TEKTON_VERSION}",
             "kind": "PipelineRun",
-            "metadata": {
-                "name": pipeline_run_name,
-                "namespace": settings.namespace,
-                "labels": {
-                    LABEL_MANAGED_BY: "fournos",
-                    LABEL_JOB_NAME: name,
-                },
-                "annotations": {
-                    "fournos.dev/cluster": cluster,
-                },
-            },
+            "metadata": metadata,
             "spec": {
                 "pipelineRef": {"name": pipeline},
+                "taskRunTemplate": {
+                    "metadata": {
+                        "labels": labels,
+                    },
+                },
                 "params": [
                     {"name": "job-name", "value": display_name},
                     {"name": "forge-project", "value": forge_project},
@@ -79,7 +89,7 @@ class TektonClient:
             plural=TEKTON_PIPELINE_RUN_PLURAL,
             body=body,
         )
-        logger.info("Created PipelineRun %s for job %s", pipeline_run_name, name)
+        logger.info("Created PipelineRun %s", name)
         return result
 
     @staticmethod
@@ -103,7 +113,7 @@ class TektonClient:
             version=TEKTON_VERSION,
             namespace=settings.namespace,
             plural=TEKTON_PIPELINE_RUN_PLURAL,
-            name=f"fournos-{name}",
+            name=name,
         )
 
     def get_pipeline_run_or_none(self, name: str) -> dict | None:
@@ -126,16 +136,15 @@ class TektonClient:
 
     def delete_pipeline_run(self, name: str) -> None:
         """Delete the PipelineRun for *name*. Ignores 404."""
-        pipeline_run_name = f"fournos-{name}"
         try:
             self._k8s.delete_namespaced_custom_object(
                 group=TEKTON_GROUP,
                 version=TEKTON_VERSION,
                 namespace=settings.namespace,
                 plural=TEKTON_PIPELINE_RUN_PLURAL,
-                name=pipeline_run_name,
+                name=name,
             )
-            logger.info("Deleted PipelineRun %s", pipeline_run_name)
+            logger.info("Deleted PipelineRun %s", name)
         except client.exceptions.ApiException as exc:
             if exc.status != 404:
                 raise

--- a/fournos/operator.py
+++ b/fournos/operator.py
@@ -26,6 +26,21 @@ _registry: ClusterRegistry
 COND_WORKLOAD_ADMITTED = "WorkloadAdmitted"
 COND_PIPELINE_RUN_READY = "PipelineRunReady"
 
+CRD_GROUP = "fournos.dev"
+CRD_VERSION = "v1"
+
+
+def _owner_ref(body: dict) -> dict:
+    """Build a Kubernetes ownerReference pointing at the given FournosJob."""
+    return {
+        "apiVersion": f"{CRD_GROUP}/{CRD_VERSION}",
+        "kind": "FournosJob",
+        "name": body["metadata"]["name"],
+        "uid": body["metadata"]["uid"],
+        "controller": True,
+        "blockOwnerDeletion": True,
+    }
+
 
 def _utcnow() -> str:
     return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -95,7 +110,7 @@ def startup(**_):
 
 @kopf.on.create("fournos.dev", "v1", "fournosjobs")
 @kopf.on.resume("fournos.dev", "v1", "fournosjobs")
-def on_create(spec, name, namespace, status, patch, **_):
+def on_create(spec, name, namespace, status, patch, body, **_):
     if status.get("phase"):
         return  # Already initialised (resume of existing CR)
 
@@ -144,6 +159,7 @@ def on_create(spec, name, namespace, status, patch, **_):
             gpu_count=hardware.get("gpuCount", 0) if hardware else 0,
             cluster=cluster,
             priority=spec.get("priority"),
+            owner_ref=_owner_ref(body),
         )
     except client.exceptions.ApiException as exc:
         if exc.status == 409:
@@ -180,13 +196,13 @@ def on_create(spec, name, namespace, status, patch, **_):
     interval=5.0,
     when=lambda status, **_: status.get("phase") in ("Pending", "Admitted", "Running"),
 )
-def reconcile(spec, name, namespace, status, patch, **_):
+def reconcile(spec, name, namespace, status, patch, body, **_):
     phase = status.get("phase", "")
 
     if phase == "Pending":
         _reconcile_pending(name, status, patch)
     elif phase == "Admitted":
-        _reconcile_admitted(spec, name, namespace, status, patch)
+        _reconcile_admitted(spec, name, namespace, status, patch, body)
     elif phase == "Running":
         _reconcile_running(name, status, patch)
 
@@ -247,7 +263,7 @@ def _reconcile_pending(name, status, patch):
         logger.info("Job %s: Workload pending admission", name)
 
 
-def _reconcile_admitted(spec, name, namespace, status, patch):
+def _reconcile_admitted(spec, name, namespace, status, patch, body):
     pr = _tekton.get_pipeline_run_or_none(name)
     conditions = list(status.get("conditions") or [])
 
@@ -271,6 +287,7 @@ def _reconcile_admitted(spec, name, namespace, status, patch):
                 gpu_count=gpu_count,
                 secret_refs=spec.get("secretRefs", []),
                 cluster=cluster,
+                owner_ref=_owner_ref(body),
             )
             logger.info(
                 "Job %s: created PipelineRun for target cluster %s", name, cluster
@@ -298,7 +315,7 @@ def _reconcile_admitted(spec, name, namespace, status, patch):
             logger.info("Job %s: PipelineRun already exists (409), proceeding", name)
 
     patch.status["phase"] = "Running"
-    patch.status["pipelineRun"] = f"fournos-{name}"
+    patch.status["pipelineRun"] = name
     patch.status["message"] = "PipelineRun created, waiting for execution"
     _set_condition(
         patch,
@@ -311,7 +328,7 @@ def _reconcile_admitted(spec, name, namespace, status, patch):
     if settings.tekton_dashboard_url:
         base = settings.tekton_dashboard_url.rstrip("/")
         patch.status["dashboardURL"] = (
-            f"{base}/#/namespaces/{namespace}/pipelineruns/fournos-{name}"
+            f"{base}/#/namespaces/{namespace}/pipelineruns/{name}"
         )
 
 
@@ -328,10 +345,10 @@ def _reconcile_running(name, status, patch):
             COND_PIPELINE_RUN_READY,
             "False",
             "NotFound",
-            f"PipelineRun fournos-{name} not found",
+            f"PipelineRun {name} not found",
         )
         _kueue.delete_workload(name)
-        logger.error("Job %s: PipelineRun fournos-%s not found", name, name)
+        logger.error("Job %s: PipelineRun %s not found", name, name)
         return
 
     pr_status, pr_message = TektonClient.extract_status(pr)
@@ -416,15 +433,3 @@ def _gc_stale_resources():
         if job_name and job_name not in job_names:
             logger.info("GC: deleting stale PipelineRun for job %s", job_name)
             _tekton.delete_pipeline_run(job_name)
-
-
-# ---------------------------------------------------------------------------
-# DELETE — clean up owned resources
-# ---------------------------------------------------------------------------
-
-
-@kopf.on.delete("fournos.dev", "v1", "fournosjobs")
-def on_delete(name, namespace, **_):
-    _kueue.delete_workload(name)
-    _tekton.delete_pipeline_run(name)
-    logger.info("Job %s: cleaned up Workload and PipelineRun", name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,18 +166,18 @@ def job_status_summary(k8s, name: str) -> str:
 
 
 def workload_exists(name: str) -> bool:
-    """Check whether the Kueue Workload ``fournos-{name}`` exists."""
+    """Check whether the Kueue Workload *name* exists."""
     result = subprocess.run(
-        ["kubectl", "get", "workload", f"fournos-{name}", "-n", NAMESPACE],
+        ["kubectl", "get", "workload", name, "-n", NAMESPACE],
         capture_output=True,
     )
     return result.returncode == 0
 
 
 def pipelinerun_exists(name: str) -> bool:
-    """Check whether the Tekton PipelineRun ``fournos-{name}`` exists."""
+    """Check whether the Tekton PipelineRun *name* exists."""
     result = subprocess.run(
-        ["kubectl", "get", "pipelinerun", f"fournos-{name}", "-n", NAMESPACE],
+        ["kubectl", "get", "pipelinerun", name, "-n", NAMESPACE],
         capture_output=True,
     )
     return result.returncode == 0
@@ -214,7 +214,7 @@ def get_k8s_resource(kind: str, name: str) -> dict:
 
 def get_workload_node_selector(name: str) -> dict:
     """Return the nodeSelector from the Workload's podSet template."""
-    wl = get_k8s_resource("workload", f"fournos-{name}")
+    wl = get_k8s_resource("workload", name)
     pod_sets = wl.get("spec", {}).get("podSets", [])
     if not pod_sets:
         return {}
@@ -223,7 +223,7 @@ def get_workload_node_selector(name: str) -> dict:
 
 def get_workload_flavor(name: str) -> str | None:
     """Return the ResourceFlavor Kueue assigned to the Workload."""
-    wl = get_k8s_resource("workload", f"fournos-{name}")
+    wl = get_k8s_resource("workload", name)
     assignments = wl.get("status", {}).get("admission", {}).get("podSetAssignments", [])
     if not assignments:
         return None
@@ -233,7 +233,7 @@ def get_workload_flavor(name: str) -> str | None:
 
 def get_pipelinerun_param(name: str, param_name: str) -> Any:
     """Return a named param value from the PipelineRun spec."""
-    pr = get_k8s_resource("pipelinerun", f"fournos-{name}")
+    pr = get_k8s_resource("pipelinerun", name)
     for p in pr.get("spec", {}).get("params", []):
         if p["name"] == param_name:
             return p["value"]
@@ -246,7 +246,7 @@ def create_stale_workload(k8s, name: str) -> None:
         "apiVersion": "kueue.x-k8s.io/v1beta2",
         "kind": "Workload",
         "metadata": {
-            "name": f"fournos-{name}",
+            "name": name,
             "namespace": NAMESPACE,
             "labels": {
                 "app.kubernetes.io/managed-by": "fournos",
@@ -291,7 +291,7 @@ def create_stale_pipelinerun(k8s, name: str) -> None:
         "apiVersion": "tekton.dev/v1",
         "kind": "PipelineRun",
         "metadata": {
-            "name": f"fournos-{name}",
+            "name": name,
             "namespace": NAMESPACE,
             "labels": {
                 "app.kubernetes.io/managed-by": "fournos",

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -73,7 +73,7 @@ def test_delete_cleans_up_resources(k8s):
         timeout=30,
     )
     assert pipelinerun_exists("test-delete"), (
-        "PipelineRun fournos-test-delete should exist before job deletion"
+        "PipelineRun test-delete should exist before job deletion"
     )
 
     k8s.delete_namespaced_custom_object(

--- a/tests/test_resource_gc.py
+++ b/tests/test_resource_gc.py
@@ -19,7 +19,7 @@ def test_stale_workload_collected(k8s):
     """A fournos-labeled Workload with no parent FournosJob is deleted by GC."""
     create_stale_workload(k8s, "stale-wl")
     assert workload_exists("stale-wl"), (
-        "Stale Workload fournos-stale-wl should exist after creation"
+        "Stale Workload stale-wl should exist after creation"
     )
 
     poll_resource_gone(workload_exists, "stale-wl", timeout=60)
@@ -29,7 +29,7 @@ def test_stale_pipelinerun_collected(k8s):
     """A fournos-labeled PipelineRun with no parent FournosJob is deleted by GC."""
     create_stale_pipelinerun(k8s, "stale-pr")
     assert pipelinerun_exists("stale-pr"), (
-        "Stale PipelineRun fournos-stale-pr should exist after creation"
+        "Stale PipelineRun stale-pr should exist after creation"
     )
 
     poll_resource_gone(pipelinerun_exists, "stale-pr", timeout=60)

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -152,7 +152,7 @@ def test_alternative_pipeline_selection(k8s):
     )
     assert phase == "Succeeded", job_status_summary(k8s, "test-run-only")
 
-    pr = get_k8s_resource("pipelinerun", "fournos-test-run-only")
+    pr = get_k8s_resource("pipelinerun", "test-run-only")
     pipeline_ref = pr["spec"]["pipelineRef"]["name"]
     assert pipeline_ref == "fournos-run-only", (
         f"PipelineRun should reference fournos-run-only, got {pipeline_ref!r}"
@@ -180,7 +180,7 @@ def test_inadmissible_stays_pending(k8s):
     )
     assert phase == "Pending", f"Inadmissible job should stay Pending, got {phase!r}"
     assert workload_exists("test-inadmissible"), (
-        "Workload fournos-test-inadmissible should still exist"
+        "Workload test-inadmissible should still exist"
     )
 
     job = get_job(k8s, "test-inadmissible")

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -125,7 +125,7 @@ def test_admitted_without_flavor(k8s):
             "kubectl",
             "patch",
             "workload",
-            "fournos-test-no-flavor",
+            "test-no-flavor",
             "-n",
             NAMESPACE,
             "--type",


### PR DESCRIPTION
This PR improves FournosJob lifecycle by relying on ownerReferences and introduces FournosJob labels on Tekton PipelineRuns and Pods. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced resource lifecycle management: operator now uses Kubernetes garbage collection via ownership references. Deleting a `FournosJob` automatically cascade-deletes associated Workload and PipelineRun resources.
  * Simplified resource naming: Workload and PipelineRun now use job names directly instead of prefixed naming convention.

* **Documentation**
  * Updated architecture documentation to clarify ownership semantics and cascade deletion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->