### PR TITLE
Make the ClusterRoleBinding manifest namespace specific

### DIFF
--- a/manifests/rbac/clusterrolebinding_fournos.yaml
+++ b/manifests/rbac/clusterrolebinding_fournos.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: fournos-cluster
+  name: fournos-cluster-${NAMESPACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed initialization order in workflow task execution to ensure proper logging.

* **Chores**
  * Updated cluster role binding to explicitly target three specific namespaces instead of dynamic namespace assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->