### PR TITLE
config: forge: workflows/tasks: don't use ARTIFACT_DIR before defining it ...

### DIFF
--- a/config/forge/workflows/tasks.yaml
+++ b/config/forge/workflows/tasks.yaml
@@ -44,10 +44,10 @@ spec:
         set -o nounset
         set -o errtrace
 
-        exec &> >(tee -a "$ARTIFACT_DIR/run.log")
-
         export ARTIFACT_DIR=/tmp/artifacts
         mkdir -p "${ARTIFACT_DIR}"
+
+        exec &> >(tee -a "$ARTIFACT_DIR/run.log")
 
         cat > $ARTIFACT_DIR/forge_config.yaml <<< "$FORGE_CONFIG"
 


### PR DESCRIPTION
…