### PR TITLE
Improve status message and logging for jobs waiting on exclusively locked clusters

### DIFF
--- a/fournos/core/constants.py
+++ b/fournos/core/constants.py
@@ -2,6 +2,7 @@ from enum import StrEnum
 
 LABEL_MANAGED_BY = "app.kubernetes.io/managed-by"
 LABEL_JOB_NAME = "fournos.dev/job-name"
+LABEL_EXCLUSIVE_CLUSTER = "fournos.dev/exclusive-cluster"
 
 CLUSTER_SLOT_RESOURCE = "fournos/cluster-slot"
 MAX_CLUSTER_SLOTS = 100

--- a/fournos/core/constants.py
+++ b/fournos/core/constants.py
@@ -16,4 +16,4 @@ class Phase(StrEnum):
     FAILED = "Failed"
 
 
-TERMINAL_PHASES = frozenset({Phase.SUCCEEDED, Phase.FAILED})
+LOCK_HOLDING_PHASES = frozenset({Phase.ADMITTED, Phase.RUNNING})

--- a/fournos/handlers/lifecycle.py
+++ b/fournos/handlers/lifecycle.py
@@ -142,7 +142,7 @@ def _find_exclusive_locker(cluster: str, exclude_job: str) -> str | None:
             label_selector=f"{LABEL_EXCLUSIVE_CLUSTER}={cluster}",
         )
     except client.exceptions.ApiException:
-        logger.debug("Failed to query exclusive locker for cluster %s", cluster)
+        logger.warning("Failed to query exclusive locker for cluster %s", cluster)
         return None
     for job in jobs.get("items", []):
         job_name = job["metadata"]["name"]

--- a/fournos/handlers/lifecycle.py
+++ b/fournos/handlers/lifecycle.py
@@ -14,7 +14,7 @@ from kubernetes import client
 from fournos.core.constants import (
     CLUSTER_SLOT_RESOURCE,
     LABEL_EXCLUSIVE_CLUSTER,
-    TERMINAL_PHASES,
+    LOCK_HOLDING_PHASES,
     Phase,
 )
 from fournos.core.kueue import KueueClient
@@ -127,21 +127,29 @@ def on_create(spec, name, namespace, status, patch, body):
 
 
 def _find_exclusive_locker(cluster: str, exclude_job: str) -> str | None:
-    """Return the name of the active exclusive job holding *cluster*, if any."""
-    custom = client.CustomObjectsApi()
-    jobs = custom.list_namespaced_custom_object(
-        CRD_GROUP,
-        CRD_VERSION,
-        settings.namespace,
-        "fournosjobs",
-        label_selector=f"{LABEL_EXCLUSIVE_CLUSTER}={cluster}",
-    )
+    """Return the name of the exclusive job actively holding *cluster*, if any.
+
+    Only jobs in Admitted or Running phase actually hold cluster-slot quota.
+    Returns None on API errors so reconciliation is not interrupted.
+    """
+    try:
+        custom = client.CustomObjectsApi()
+        jobs = custom.list_namespaced_custom_object(
+            CRD_GROUP,
+            CRD_VERSION,
+            settings.namespace,
+            "fournosjobs",
+            label_selector=f"{LABEL_EXCLUSIVE_CLUSTER}={cluster}",
+        )
+    except client.exceptions.ApiException:
+        logger.debug("Failed to query exclusive locker for cluster %s", cluster)
+        return None
     for job in jobs.get("items", []):
         job_name = job["metadata"]["name"]
         if job_name == exclude_job:
             continue
         phase = job.get("status", {}).get("phase", "")
-        if phase and phase not in TERMINAL_PHASES:
+        if phase in LOCK_HOLDING_PHASES:
             return job_name
     return None
 

--- a/fournos/handlers/lifecycle.py
+++ b/fournos/handlers/lifecycle.py
@@ -11,11 +11,19 @@ import logging
 
 from kubernetes import client
 
-from fournos.core.constants import CLUSTER_SLOT_RESOURCE, Phase
+from fournos.core.constants import (
+    CLUSTER_SLOT_RESOURCE,
+    LABEL_EXCLUSIVE_CLUSTER,
+    TERMINAL_PHASES,
+    Phase,
+)
 from fournos.core.kueue import KueueClient
+from fournos.settings import settings
 from fournos.state import ctx
 
 from .status import (
+    CRD_GROUP,
+    CRD_VERSION,
     COND_WORKLOAD_ADMITTED,
     create_workload_for_job,
     set_condition,
@@ -83,6 +91,9 @@ def on_create(spec, name, namespace, status, patch, body):
             )
             return
 
+    if exclusive:
+        patch.meta.setdefault("labels", {})[LABEL_EXCLUSIVE_CLUSTER] = cluster
+
     try:
         create_workload_for_job(spec, name, body)
     except client.exceptions.ApiException as exc:
@@ -115,10 +126,31 @@ def on_create(spec, name, namespace, status, patch, body):
 # ---------------------------------------------------------------------------
 
 
+def _find_exclusive_locker(cluster: str, exclude_job: str) -> str | None:
+    """Return the name of the active exclusive job holding *cluster*, if any."""
+    custom = client.CustomObjectsApi()
+    jobs = custom.list_namespaced_custom_object(
+        CRD_GROUP,
+        CRD_VERSION,
+        settings.namespace,
+        "fournosjobs",
+        label_selector=f"{LABEL_EXCLUSIVE_CLUSTER}={cluster}",
+    )
+    for job in jobs.get("items", []):
+        job_name = job["metadata"]["name"]
+        if job_name == exclude_job:
+            continue
+        phase = job.get("status", {}).get("phase", "")
+        if phase and phase not in TERMINAL_PHASES:
+            return job_name
+    return None
+
+
 def _pending_status(
     wl_message: str,
     cluster: str | None,
     exclusive: bool,
+    locker: str | None = None,
 ) -> tuple[str, str]:
     """Return (user_message, log_message) with cluster-slot context when applicable."""
     if not wl_message:
@@ -135,11 +167,20 @@ def _pending_status(
             f"exclusive job waiting for cluster {cluster} to clear (slot contention)"
         )
     elif is_slot_issue and cluster:
+        locker_label = f"job {locker}" if locker else "another job"
         user_msg = (
-            f"Cluster {cluster} is exclusively locked by another job, "
+            f"Cluster {cluster} is exclusively locked by {locker_label}, "
             f"waiting for it to finish"
         )
-        log_msg = f"cluster {cluster} exclusively locked (slot contention)"
+        if locker:
+            log_msg = (
+                f"cluster {cluster} exclusively locked by {locker} (slot contention)"
+            )
+        else:
+            log_msg = (
+                f"cluster {cluster} exclusively locked (slot contention, "
+                f"locker not found — may have just finished)"
+            )
     elif is_slot_issue:
         user_msg = (
             "All eligible clusters are exclusively locked, waiting for availability"
@@ -162,10 +203,15 @@ def reconcile_pending(spec, name, status, patch, body):
 
     if not KueueClient.is_admitted(wl):
         wl_reason, wl_message = KueueClient.get_pending_message(wl)
+        cluster = spec.get("cluster")
+        locker = None
+        if cluster and CLUSTER_SLOT_RESOURCE in wl_message:
+            locker = _find_exclusive_locker(cluster, name)
         new_msg, log_msg = _pending_status(
             wl_message,
-            spec.get("cluster"),
+            cluster,
             spec.get("exclusive", False),
+            locker,
         )
         if status.get("message") != new_msg:
             patch.status["message"] = new_msg

--- a/tests/test_exclusive.py
+++ b/tests/test_exclusive.py
@@ -178,6 +178,9 @@ def test_exclusive_blocks_cluster_pinned_job(k8s):
     assert "cluster-2" in msg, (
         f"Message should mention the locked cluster, got: {msg!r}"
     )
+    assert "test-excl-lock" in msg, (
+        f"Message should name the exclusive job holding the lock, got: {msg!r}"
+    )
 
     poll_phase(
         k8s,
@@ -341,6 +344,9 @@ def test_lock_released_on_completion(k8s):
     msg = get_job(k8s, "test-waiting")["status"]["message"]
     assert "cluster-1" in msg, (
         f"Message should mention the locked cluster, got: {msg!r}"
+    )
+    assert "test-excl-release" in msg, (
+        f"Message should name the exclusive job holding the lock, got: {msg!r}"
     )
 
     poll_phase(


### PR DESCRIPTION
This PR adds a `fournos.dev/exclusive-cluster` on jobs that lock clusters exclusive and additional status message/logging to point to the locker job.
Closes #40 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cluster-exclusive jobs are now labeled for identification and tracking.
  * Pending jobs blocked by exclusive workloads now display the specific blocking job name in their status messages.
  * Enhanced messaging provides clearer visibility when cluster slots are contested or a locker cannot be found.

* **Tests**
  * Extended tests to validate status messages include the specific exclusive locking job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->