### PR TITLE
Fix Secrets Mounting

### DIFF
--- a/config/forge/workflows/tasks.yaml
+++ b/config/forge/workflows/tasks.yaml
@@ -33,6 +33,8 @@ spec:
         value: "$(params.env)"
       - name: FOURNOS_STEP
         value: "$(params.job-step)"
+      - name: FOURNOS_SECRETS
+        value: /var/run/secrets/fournos
       volumeMounts:
         - name: kubeconfig
           mountPath: /var/run/secrets/fournos-kubeconfig

--- a/dev/mock-resolve/resolve.sh
+++ b/dev/mock-resolve/resolve.sh
@@ -33,6 +33,6 @@ echo "[mock-resolve] setting secretRefs"
 kubectl patch fournosjob "${FOURNOS_JOB_NAME}" \
   -n "${FOURNOS_NAMESPACE}" \
   --type=merge \
-  -p '{"spec":{"secretRefs":["vault-placeholder"]}}'
+  -p '{"spec":{"secretRefs":["placeholder"]}}'
 
 echo "[mock-resolve] done"

--- a/dev/mock-secrets.yaml
+++ b/dev/mock-secrets.yaml
@@ -40,13 +40,15 @@ stringData:
 
 ---
 # Mock Vault-synced secret for the secret-demo sample job.
+# Uses managed-by: fournos-mock (not fournos-vault-sync) so the
+# destructive sync in sync_vault_secrets.py won't garbage-collect it.
 apiVersion: v1
 kind: Secret
 metadata:
   name: vault-placeholder
   labels:
     fournos.dev/vault-entry: "true"
-    app.kubernetes.io/managed-by: fournos-vault-sync
+    app.kubernetes.io/managed-by: fournos-mock
 type: Opaque
 stringData:
   placeholder: "mock-secret-value"

--- a/fournos/core/clusters.py
+++ b/fournos/core/clusters.py
@@ -28,6 +28,57 @@ class ClusterRegistry:
         """Return the Secret name that holds the kubeconfig for *cluster_name*."""
         return settings.kubeconfig_secret_pattern.format(cluster=cluster_name)
 
+    def copy_kubeconfig_secret(
+        self, cluster_name: str, fjob_name: str, owner_ref: dict
+    ) -> str:
+        """Copy the kubeconfig Secret for *cluster_name* into the operator namespace.
+
+        Returns the name of the copied Secret (``<fjob_name>-kubeconfig``).
+        Idempotent: a 409 (AlreadyExists) is silently ignored.
+        """
+        source_name = self.resolve_kubeconfig_secret(cluster_name)
+        source = self._k8s.read_namespaced_secret(
+            source_name, settings.secrets_namespace
+        )
+
+        copied_name = f"{fjob_name}-kubeconfig"
+
+        copy_body = client.V1Secret(
+            metadata=client.V1ObjectMeta(
+                name=copied_name,
+                namespace=settings.namespace,
+                labels={LABEL_MANAGED_BY: "fournos"},
+                owner_references=[
+                    client.V1OwnerReference(
+                        api_version=owner_ref["apiVersion"],
+                        kind=owner_ref["kind"],
+                        name=owner_ref["name"],
+                        uid=owner_ref["uid"],
+                        controller=False,
+                        block_owner_deletion=True,
+                    )
+                ],
+            ),
+            type=source.type,
+            data=source.data,
+        )
+
+        try:
+            self._k8s.create_namespaced_secret(settings.namespace, copy_body)
+            logger.info(
+                "Copied kubeconfig %s from %s as %s",
+                source_name,
+                settings.secrets_namespace,
+                copied_name,
+            )
+        except client.exceptions.ApiException as exc:
+            if exc.status == 409:
+                logger.debug("Kubeconfig copy %s already exists (409)", copied_name)
+            else:
+                raise
+
+        return copied_name
+
     def cluster_exists(self, cluster_name: str) -> bool:
         """Return True if the kubeconfig Secret for *cluster_name* exists."""
         secret_name = self.resolve_kubeconfig_secret(cluster_name)
@@ -39,33 +90,43 @@ class ClusterRegistry:
                 return False
             raise
 
+    @staticmethod
+    def _vault_secret_name(ref: str) -> str:
+        """Apply the vault secret naming pattern to a user-supplied ref."""
+        return settings.vault_secret_pattern.format(entry=ref)
+
     def _resolve_secret_ref(self, ref: str) -> str:
         """Verify that *ref* is a Vault-synced K8s Secret and return its name.
 
-        The Secret is read from ``secrets_namespace``.  The
-        ``fournos.dev/vault-entry=true`` label is checked to confirm
+        Users supply refs without the ``vault-`` prefix; the pattern from
+        ``settings.vault_secret_pattern`` is applied to derive the real
+        Secret name.  The Secret is read from ``secrets_namespace``.
+        The ``fournos.dev/vault-entry=true`` label is checked to confirm
         the Secret was actually imported from Vault.
 
         Raises ``KeyError`` if the Secret does not exist or is not
         a Vault-synced secret.
         """
+        secret_name = self._vault_secret_name(ref)
         try:
-            secret = self._k8s.read_namespaced_secret(ref, settings.secrets_namespace)
+            secret = self._k8s.read_namespaced_secret(
+                secret_name, settings.secrets_namespace
+            )
         except client.exceptions.ApiException as exc:
             if exc.status == 404:
                 raise KeyError(
-                    f"Secret {ref!r} not found in namespace "
-                    f"{settings.secrets_namespace}"
+                    f"Secret {secret_name!r} (ref {ref!r}) not found in "
+                    f"namespace {settings.secrets_namespace}"
                 ) from exc
             raise
         labels = secret.metadata.labels or {}
         if labels.get(LABEL_VAULT_ENTRY) != "true":
             raise KeyError(
-                f"Secret {ref!r} exists but is not a Vault-synced secret "
+                f"Secret {secret_name!r} exists but is not a Vault-synced secret "
                 f"(missing {LABEL_VAULT_ENTRY}=true label)"
             )
-        logger.debug("Validated secretRef %s", ref)
-        return ref
+        logger.debug("Validated secretRef %s -> %s", ref, secret_name)
+        return secret_name
 
     def resolve_secret_refs(self, refs: list[str]) -> list[str]:
         """Resolve a list of secretRefs to their K8s Secret names."""
@@ -74,16 +135,20 @@ class ClusterRegistry:
     def copy_secret(self, ref: str, fjob_name: str, owner_ref: dict) -> ResolvedSecret:
         """Copy a Vault-synced Secret from the secrets namespace into the pod namespace.
 
+        *ref* is the user-supplied name (without ``vault-`` prefix).
         The copy is named ``<fjob_name>-<ref>`` and carries an ownerReference
         back to the FournosJob so K8s GC cleans it up automatically.
         Idempotent: a 409 (AlreadyExists) is silently ignored.
         """
-        source = self._k8s.read_namespaced_secret(ref, settings.secrets_namespace)
+        secret_name = self._vault_secret_name(ref)
+        source = self._k8s.read_namespaced_secret(
+            secret_name, settings.secrets_namespace
+        )
 
         labels = source.metadata.labels or {}
         if labels.get(LABEL_VAULT_ENTRY) != "true":
             raise KeyError(
-                f"Secret {ref!r} in {settings.secrets_namespace} is not a "
+                f"Secret {secret_name!r} in {settings.secrets_namespace} is not a "
                 f"Vault-synced secret (missing {LABEL_VAULT_ENTRY}=true label)"
             )
 
@@ -116,7 +181,8 @@ class ClusterRegistry:
         try:
             self._k8s.create_namespaced_secret(settings.namespace, copy_body)
             logger.info(
-                "Copied secret %s from %s as %s",
+                "Copied secret %s (ref %s) from %s as %s",
+                secret_name,
                 ref,
                 settings.secrets_namespace,
                 copied_name,

--- a/fournos/core/clusters.py
+++ b/fournos/core/clusters.py
@@ -95,8 +95,8 @@ class ClusterRegistry:
         """Apply the vault secret naming pattern to a user-supplied ref."""
         return settings.vault_secret_pattern.format(entry=ref)
 
-    def _resolve_secret_ref(self, ref: str) -> str:
-        """Verify that *ref* is a Vault-synced K8s Secret and return its name.
+    def _resolve_secret_ref(self, ref: str) -> client.V1Secret:
+        """Verify that *ref* is a Vault-synced K8s Secret and return it.
 
         Users supply refs without the ``vault-`` prefix; the pattern from
         ``settings.vault_secret_pattern`` is applied to derive the real
@@ -126,11 +126,11 @@ class ClusterRegistry:
                 f"(missing {LABEL_VAULT_ENTRY}=true label)"
             )
         logger.debug("Validated secretRef %s -> %s", ref, secret_name)
-        return secret_name
+        return secret
 
     def resolve_secret_refs(self, refs: list[str]) -> list[str]:
         """Resolve a list of secretRefs to their K8s Secret names."""
-        return [self._resolve_secret_ref(r) for r in refs]
+        return [self._resolve_secret_ref(r).metadata.name for r in refs]
 
     def copy_secret(self, ref: str, fjob_name: str, owner_ref: dict) -> ResolvedSecret:
         """Copy a Vault-synced Secret from the secrets namespace into the pod namespace.
@@ -140,10 +140,8 @@ class ClusterRegistry:
         back to the FournosJob so K8s GC cleans it up automatically.
         Idempotent: a 409 (AlreadyExists) is silently ignored.
         """
-        secret_name = self._resolve_secret_ref(ref)
-        source = self._k8s.read_namespaced_secret(
-            secret_name, settings.secrets_namespace
-        )
+        source = self._resolve_secret_ref(ref)
+        secret_name = source.metadata.name
 
         keys = sorted((source.data or {}).keys())
         copied_name = f"{fjob_name}-{ref}"

--- a/fournos/core/clusters.py
+++ b/fournos/core/clusters.py
@@ -140,17 +140,10 @@ class ClusterRegistry:
         back to the FournosJob so K8s GC cleans it up automatically.
         Idempotent: a 409 (AlreadyExists) is silently ignored.
         """
-        secret_name = self._vault_secret_name(ref)
+        secret_name = self._resolve_secret_ref(ref)
         source = self._k8s.read_namespaced_secret(
             secret_name, settings.secrets_namespace
         )
-
-        labels = source.metadata.labels or {}
-        if labels.get(LABEL_VAULT_ENTRY) != "true":
-            raise KeyError(
-                f"Secret {secret_name!r} in {settings.secrets_namespace} is not a "
-                f"Vault-synced secret (missing {LABEL_VAULT_ENTRY}=true label)"
-            )
 
         keys = sorted((source.data or {}).keys())
         copied_name = f"{fjob_name}-{ref}"

--- a/fournos/handlers/execution.py
+++ b/fournos/handlers/execution.py
@@ -147,7 +147,25 @@ def reconcile_admitted(spec, name, namespace, status, patch, body):
 
     if pr is None:
         cluster = status.get("cluster", "")
-        secret = ctx.registry.resolve_kubeconfig_secret(cluster)
+
+        try:
+            kubeconfig_secret = ctx.registry.copy_kubeconfig_secret(
+                cluster, name, owner_ref(body)
+            )
+        except client.exceptions.ApiException as exc:
+            patch.status["phase"] = Phase.FAILED
+            patch.status["message"] = f"Failed to copy kubeconfig: {exc.reason}"
+            set_condition(
+                patch,
+                conditions,
+                COND_PIPELINE_RUN_READY,
+                "False",
+                "KubeconfigNotFound",
+                f"Failed to copy kubeconfig: {exc.reason}",
+            )
+            ctx.kueue.delete_workload(name)
+            logger.error("Job %s: kubeconfig copy failed: %s", name, exc)
+            return
 
         hardware = spec.get("hardware") or {}
         gpu_count = hardware.get("gpuCount", 0)
@@ -183,7 +201,7 @@ def reconcile_admitted(spec, name, namespace, status, patch, body):
                 forge_project=spec["forge"]["project"],
                 forge_config=spec["forge"],
                 env=spec.get("env", {}),
-                kubeconfig_secret=secret,
+                kubeconfig_secret=kubeconfig_secret,
                 gpu_count=gpu_count,
                 resolved_secrets=resolved_secrets,
                 cluster=cluster,

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -101,11 +101,12 @@ spec:
                 secretRefs:
                   type: array
                   description: >-
-                    Vault-synced K8s Secret names (vault-<entry>) to mount
-                    into the pipeline.  Each name must correspond to a
-                    Kubernetes Secret with the fournos.dev/vault-entry=true
-                    label.  Populated by Forge during the Resolving phase
-                    when not provided by the user.
+                    Vault entry names (without the vault- prefix) to mount
+                    into the pipeline.  The operator prepends vault- to
+                    look up the corresponding K8s Secret (which must carry
+                    the fournos.dev/vault-entry=true label) in the secrets
+                    namespace.  Populated by Forge during the Resolving
+                    phase when not provided by the user.
                   items:
                     type: string
                     pattern: "^[a-z0-9]([a-z0-9\\-]{0,61}[a-z0-9])?$"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -464,7 +464,7 @@ def create_stale_pipelinerun(k8s, name: str) -> None:
                     """),
                 },
                 {"name": "env", "value": ""},
-                {"name": "kubeconfig-secret", "value": "test-stale-kubeconfig"},
+                {"name": "kubeconfig-secret", "value": f"{name}-kubeconfig"},
                 {"name": "gpu-count", "value": "0"},
             ],
         },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -464,7 +464,7 @@ def create_stale_pipelinerun(k8s, name: str) -> None:
                     """),
                 },
                 {"name": "env", "value": ""},
-                {"name": "kubeconfig-secret", "value": "kubeconfig-cluster-1"},
+                {"name": "kubeconfig-secret", "value": "test-stale-kubeconfig"},
                 {"name": "gpu-count", "value": "0"},
             ],
         },

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -61,6 +61,11 @@ def test_cluster_pinned(k8s):
         "Copied kubeconfig should be in the operator namespace"
     )
 
+    refs = get_pipelinerun_param("test-cluster", "secret-refs")
+    assert refs == ["placeholder"], (
+        f"Mock resolver should set secret-refs to ['placeholder'], got {refs!r}"
+    )
+
     phase = poll_phase(
         k8s,
         "test-cluster",

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -4,6 +4,7 @@ import yaml
 
 from fournos.core.constants import Phase
 from tests.conftest import (
+    NAMESPACE,
     create_job,
     get_job,
     get_k8s_resource,
@@ -43,8 +44,21 @@ def test_cluster_pinned(k8s):
     flavor = get_workload_flavor("test-cluster")
     assert flavor == "cluster-2", f"Workload flavor should be cluster-2, got {flavor!r}"
     secret = get_pipelinerun_param("test-cluster", "kubeconfig-secret")
-    assert secret == "kubeconfig-cluster-2", (
-        f"PipelineRun kubeconfig-secret should be kubeconfig-cluster-2, got {secret!r}"
+    assert secret == "test-cluster-kubeconfig", (
+        f"PipelineRun kubeconfig-secret should be test-cluster-kubeconfig, got {secret!r}"
+    )
+
+    kc = get_k8s_resource("secret", "test-cluster-kubeconfig")
+    assert "kubeconfig" in (kc.get("data") or {}), (
+        f"Copied kubeconfig secret should have a 'kubeconfig' key, got {list((kc.get('data') or {}).keys())}"
+    )
+    kc_owners = kc.get("metadata", {}).get("ownerReferences", [])
+    assert any(
+        o.get("kind") == "FournosJob" and o.get("name") == "test-cluster"
+        for o in kc_owners
+    ), f"Copied kubeconfig should have FournosJob ownerRef, got {kc_owners!r}"
+    assert kc.get("metadata", {}).get("namespace") == NAMESPACE, (
+        "Copied kubeconfig should be in the operator namespace"
     )
 
     phase = poll_phase(
@@ -115,8 +129,8 @@ def test_cluster_and_hardware(k8s):
     flavor = get_workload_flavor("test-cluster-hw")
     assert flavor == "cluster-4", f"Workload flavor should be cluster-4, got {flavor!r}"
     secret = get_pipelinerun_param("test-cluster-hw", "kubeconfig-secret")
-    assert secret == "kubeconfig-cluster-4", (
-        f"PipelineRun kubeconfig-secret should be kubeconfig-cluster-4, got {secret!r}"
+    assert secret == "test-cluster-hw-kubeconfig", (
+        f"PipelineRun kubeconfig-secret should be test-cluster-hw-kubeconfig, got {secret!r}"
     )
 
     phase = poll_phase(

--- a/tests/test_secret_refs.py
+++ b/tests/test_secret_refs.py
@@ -5,9 +5,8 @@ the Resolving phase.  The Vault HTTP layer is mocked so no real Vault is
 needed, but secrets are created on the live cluster by the sync script,
 then consumed by a FournosJob whose spec.secretRefs references them.
 
-Both tests create the FournosJob first.  The operator launches a resolve
-Job; after it completes the test patches ``spec.secretRefs`` on the
-FournosJob before the operator's next timer tick validates them.
+Both tests use a noop resolve Job to avoid races with the mock resolver,
+and supply ``secretRefs`` directly in the FournosJob spec.
 """
 
 from __future__ import annotations
@@ -25,11 +24,11 @@ from tests.conftest import (
     NAMESPACE,
     SECRETS_NAMESPACE,
     create_job,
+    create_noop_resolve_job,
     get_pipelinerun_param,
     get_pipelinerun_volumes,
     job_status_summary,
     poll_phase,
-    poll_resolve_job_complete,
 )
 
 # ---------------------------------------------------------------------------
@@ -54,9 +53,6 @@ VAULT_DATA = {
     "secretsync/target-namespace": "should-be-filtered",
 }
 
-GROUP = "fournos.dev"
-VERSION = "v1"
-
 
 @pytest.fixture(scope="session")
 def core_v1():
@@ -75,18 +71,6 @@ def _delete_secret_if_exists(v1, name: str, namespace: str = SECRETS_NAMESPACE) 
             raise
 
 
-def _patch_fjob_secret_refs(k8s, job_name: str, secret_refs: list[str]) -> None:
-    """Patch the FournosJob to set ``spec.secretRefs``."""
-    k8s.patch_namespaced_custom_object(
-        GROUP,
-        VERSION,
-        NAMESPACE,
-        "fournosjobs",
-        job_name,
-        body={"spec": {"secretRefs": secret_refs}},
-    )
-
-
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -95,10 +79,9 @@ def _patch_fjob_secret_refs(k8s, job_name: str, secret_refs: list[str]) -> None:
 def test_vault_sync_then_fjob(k8s, core_v1):
     """Sync a mocked Vault entry, then verify a FournosJob passes it to PipelineRun.
 
-    The FournosJob is created first.  The operator launches the resolve
-    Job.  After the resolve Job completes, the test patches secretRefs
-    on the FournosJob before the operator reads the spec for the Pending
-    transition.
+    A noop resolve Job is pre-created so the mock resolver doesn't
+    overwrite ``secretRefs``.  The FournosJob carries ``secretRefs``
+    directly in its spec, avoiding any race with the resolver.
     """
 
     with (
@@ -121,20 +104,20 @@ def test_vault_sync_then_fjob(k8s, core_v1):
         secret = core_v1.read_namespaced_secret(VAULT_SECRET, SECRETS_NAMESPACE)
         assert secret.metadata.labels[LABEL_VAULT_ENTRY] == "true"
 
+        create_noop_resolve_job("test-e2e-secret")
+
         create_job(
             k8s,
             "test-e2e-secret",
             {
                 "cluster": "cluster-1",
+                "secretRefs": [VAULT_ENTRY],
                 "forge": {
                     "project": "testproj/llmd",
                     "args": ["cks", "internal-test"],
                 },
             },
         )
-
-        poll_resolve_job_complete("test-e2e-secret")
-        _patch_fjob_secret_refs(k8s, "test-e2e-secret", [VAULT_ENTRY])
 
         phase = poll_phase(
             k8s,
@@ -147,9 +130,8 @@ def test_vault_sync_then_fjob(k8s, core_v1):
         )
 
         refs_param = get_pipelinerun_param("test-e2e-secret", "secret-refs")
-        assert VAULT_ENTRY in refs_param, (
-            f"PipelineRun secret-refs should contain {VAULT_ENTRY!r}, "
-            f"got {refs_param!r}"
+        assert refs_param == [VAULT_ENTRY], (
+            f"PipelineRun secret-refs should be {[VAULT_ENTRY]!r}, got {refs_param!r}"
         )
 
         volumes = get_pipelinerun_volumes("test-e2e-secret")
@@ -189,23 +171,24 @@ def test_vault_sync_then_fjob(k8s, core_v1):
 def test_missing_secret_ref_fails(k8s):
     """A secretRef with no matching labelled Secret fails the job.
 
-    The test waits for the resolve Job to complete, then patches
-    secretRefs on the FournosJob to reference a nonexistent secret.
+    A noop resolve Job is pre-created so the mock resolver doesn't
+    inject valid secretRefs.  The FournosJob carries a nonexistent ref
+    directly in its spec.
     """
+    create_noop_resolve_job("test-missing-ref")
+
     create_job(
         k8s,
         "test-missing-ref",
         {
             "cluster": "cluster-1",
+            "secretRefs": ["nonexistent-vault-entry"],
             "forge": {
                 "project": "testproj/llmd",
                 "args": ["cks", "internal-test"],
             },
         },
     )
-
-    poll_resolve_job_complete("test-missing-ref")
-    _patch_fjob_secret_refs(k8s, "test-missing-ref", ["nonexistent-vault-entry"])
 
     phase = poll_phase(
         k8s,

--- a/tests/test_secret_refs.py
+++ b/tests/test_secret_refs.py
@@ -115,7 +115,7 @@ def test_vault_sync_then_fjob(k8s, core_v1):
         )
     assert rc == 0, "sync_vault_secrets.sync() returned non-zero"
 
-    expected_copy = f"test-e2e-secret-{VAULT_SECRET}"
+    expected_copy = f"test-e2e-secret-{VAULT_ENTRY}"
 
     try:
         secret = core_v1.read_namespaced_secret(VAULT_SECRET, SECRETS_NAMESPACE)
@@ -134,7 +134,7 @@ def test_vault_sync_then_fjob(k8s, core_v1):
         )
 
         poll_resolve_job_complete("test-e2e-secret")
-        _patch_fjob_secret_refs(k8s, "test-e2e-secret", [VAULT_SECRET])
+        _patch_fjob_secret_refs(k8s, "test-e2e-secret", [VAULT_ENTRY])
 
         phase = poll_phase(
             k8s,
@@ -147,8 +147,8 @@ def test_vault_sync_then_fjob(k8s, core_v1):
         )
 
         refs_param = get_pipelinerun_param("test-e2e-secret", "secret-refs")
-        assert VAULT_SECRET in refs_param, (
-            f"PipelineRun secret-refs should contain {VAULT_SECRET!r}, "
+        assert VAULT_ENTRY in refs_param, (
+            f"PipelineRun secret-refs should contain {VAULT_ENTRY!r}, "
             f"got {refs_param!r}"
         )
 

--- a/tests/test_secret_refs.py
+++ b/tests/test_secret_refs.py
@@ -111,6 +111,7 @@ def test_vault_sync_then_fjob(k8s, core_v1):
             "test-e2e-secret",
             {
                 "cluster": "cluster-1",
+                "hardware": {"gpuType": "a100", "gpuCount": 2},
                 "secretRefs": [VAULT_ENTRY],
                 "forge": {
                     "project": "testproj/llmd",
@@ -182,6 +183,7 @@ def test_missing_secret_ref_fails(k8s):
         "test-missing-ref",
         {
             "cluster": "cluster-1",
+            "hardware": {"gpuType": "a100", "gpuCount": 2},
             "secretRefs": ["nonexistent-vault-entry"],
             "forge": {
                 "project": "testproj/llmd",


### PR DESCRIPTION
Fix naming pattern for vault secrets, copy kubeconfig to target ns and add FOURNOS_SECRETS envvar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kubeconfig secrets are now copied per job with ownership tracking and idempotent creation.

* **Improvements**
  * Secret references accept simplified Vault entry names (no "vault-" prefix); CRD docs updated.
  * Better error handling and clearer logging when secret operations fail.

* **Tests**
  * Scheduling and secret-related tests updated to validate job-scoped kubeconfig naming and copied secret contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->