### PR TITLE
Refine scheduling for exclusive, cluster and hw spec configs

### DIFF
--- a/Fournos_Design_Document.md
+++ b/Fournos_Design_Document.md
@@ -48,7 +48,7 @@ Jobs are submitted as `FournosJob` custom resources ([manifests/crd.yaml](manife
 | `spec.forge.args`            | yes          | List of arguments passed to FORGE                                                                |
 | `spec.forge.configOverrides` | no           | Arbitrary YAML overrides passed to the test framework                                            |
 | `spec.env`                   | no           | Environment variables passed to the pipeline as a `KEY=VALUE` env file                           |
-| `spec.cluster`               |              | Pin to a specific cluster (Kueue ResourceFlavor)                                                 |
+| `spec.cluster`               |              | Pin to a specific cluster (Kueue ResourceFlavor). Since `exclusive` defaults to `true`, this also locks the cluster — set `exclusive: false` for shared access. |
 | `spec.hardware.gpuType`      |              | Short GPU model name (e.g. `a100`, `h200`). The operator adds the resource prefix automatically. |
 | `spec.hardware.gpuCount`     | with gpuType | Number of GPUs (minimum 1)                                                                       |
 | `spec.owner`                 | no           | Team or individual that owns this job                                                            |
@@ -56,11 +56,11 @@ Jobs are submitted as `FournosJob` custom resources ([manifests/crd.yaml](manife
 | `spec.pipeline`              | no           | Tekton Pipeline name (default: `fournos-full`)                                                   |
 | `spec.priority`              | no           | Kueue WorkloadPriorityClass name                                                                 |
 | `spec.secretRefs`            | no           | Vault-synced K8s Secret names (`vault-<entry>`) to mount into the pipeline. Populated by Forge during the Resolving phase. Each must be a K8s Secret with `fournos.dev/vault-entry=true` in `FOURNOS_SECRETS_NAMESPACE`. During the Admitted phase the operator copies them into the operator namespace and mounts them as a projected volume at `/var/run/secrets/fournos/<entry-name>/`. |
-| `spec.exclusive`             | no           | If `true`, locks the target cluster so no other FournosJob can run there. Requires `spec.cluster`. |
+| `spec.exclusive`             | no (default `true`) | If `true`, locks the target cluster so no other FournosJob can run there. Requires `spec.cluster`. Hardware is optional — when omitted the Workload only requests cluster-slot resources for locking. |
 | `spec.shutdown`              | no           | Shutdown action: `Stop` (graceful, runs finally tasks) or `Terminate` (immediate, skips finally tasks). Both wait for the PipelineRun to finish before releasing Kueue quota. |
 
 
-`spec.cluster` and `spec.hardware` are both optional. Every job passes through the mandatory Resolving phase where Forge populates `spec.hardware` (if not already set) and `spec.secretRefs` directly on the FournosJob. `spec.cluster` can be set alongside `spec.hardware` to pin a hardware request to a specific cluster.
+`spec.hardware` is required unless the job uses exclusive cluster locking (`exclusive: true` + `cluster`), in which case it may be omitted — the Workload only needs cluster-slot resources. Every job passes through the mandatory Resolving phase where Forge populates `spec.hardware` (if not already set) and `spec.secretRefs` directly on the FournosJob. Since `exclusive` defaults to `true`, any job with `spec.cluster` locks the cluster exclusively — including jobs that also specify `spec.hardware`. Set `exclusive: false` for shared access. Jobs without `spec.cluster` must set `exclusive: false`.
 
 `metadata.name` is the unique identifier for the job. Use `metadata.generateName` for auto-generated unique names (e.g. `generateName: nightly-benchmark-` produces `nightly-benchmark-x7k2m`). `spec.displayName` is a human-readable label for external correlation — it does not need to be unique and is passed to the pipeline as `job-name`.
 
@@ -112,22 +112,25 @@ kubectl delete fournosjob <name>     # cleanup
 All jobs flow through Kueue — there is one scheduling path with different constraint levels:
 
 
-| User specifies                             | Workload nodeSelector                          | Kueue behavior                                                          |
-| ------------------------------------------ | ---------------------------------------------- | ----------------------------------------------------------------------- |
-| `cluster: "cluster-1"`                     | `fournos.dev/cluster: cluster-1`               | Only the `cluster-1` flavor is eligible. Queues if the cluster is full. |
-| `hardware: {gpuType: "a100", gpuCount: 2}` | *(none)*                                       | All flavors with enough A100 quota are eligible. Kueue picks first fit. |
-| Both                                       | `fournos.dev/cluster: cluster-1` + GPU request | Specific hardware on a specific cluster.                                |
+| User specifies                                       | Workload nodeSelector                          | Kueue behavior                                                          |
+| ---------------------------------------------------- | ---------------------------------------------- | ----------------------------------------------------------------------- |
+| `cluster` (default: exclusive)                       | `fournos.dev/cluster: cluster-1`               | Locks the cluster (100 cluster-slots). Hardware optional — GPU request included only if set. |
+| `cluster` + `hardware` (default: exclusive)          | `fournos.dev/cluster: cluster-1` + GPU request | Locks the cluster (100 cluster-slots) and requests specific GPUs.       |
+| `exclusive: false` + `cluster` + `hardware`          | `fournos.dev/cluster: cluster-1` + GPU request | Shared access (1 cluster-slot) with specific hardware on a specific cluster. |
+| `exclusive: false` + `hardware` (no cluster)         | *(none)*                                       | All flavors with enough GPU quota are eligible. Kueue picks first fit.  |
 
 
 Each ResourceFlavor has `spec.nodeLabels: { fournos.dev/cluster: <name> }`. When `cluster` is specified, the operator sets a matching `nodeSelector` on the Workload's podSet template so Kueue constrains admission to that flavor.
 
+Because `exclusive` defaults to `true`, any job with `spec.cluster` automatically locks the assigned cluster — including jobs that also specify `spec.hardware`. To get shared access (multiple jobs on the same cluster), set `exclusive: false` explicitly. Jobs without `spec.cluster` must set `exclusive: false` (since exclusive mode requires a cluster target). Hardware is always required for non-exclusive jobs — only exclusive cluster-locked jobs may omit it.
+
 ### Exclusive cluster locking
 
-When `spec.exclusive: true` is set (requires `spec.cluster`), the operator enforces full exclusivity using a **Kueue cluster-slot semaphore**:
+Jobs default to `spec.exclusive: true` (requires `spec.cluster`). The operator enforces full exclusivity using a **Kueue cluster-slot semaphore**:
 
 - Every Kueue `ClusterQueue` flavor carries a virtual resource `fournos/cluster-slot` with a quota of 100.
-- **Normal jobs** request 1 cluster-slot in their Workload.
-- **Exclusive jobs** request all 100 cluster-slots for their target cluster.
+- **Non-exclusive jobs** (`exclusive: false`) request 1 cluster-slot in their Workload.
+- **Exclusive jobs** (the default) request all 100 cluster-slots for their target cluster.
 
 This means Kueue itself enforces exclusivity atomically:
 - While an exclusive Workload holds all 100 slots, no other Workload can be admitted to that cluster (0 slots remaining).
@@ -135,6 +138,8 @@ This means Kueue itself enforces exclusivity atomically:
 - Hardware-only jobs are automatically steered to clusters with available slots — no operator-side anti-affinity is needed.
 
 The lock is implicitly released when the exclusive job completes and the operator deletes its Workload, freeing all 100 slots. No operator-level blocking phase, labels, or in-memory state is required.
+
+Exclusive jobs with a cluster may omit `spec.hardware` — the Workload only needs cluster-slot resources for locking. When hardware is also specified, the Workload requests both GPU resources and all 100 cluster-slots.
 
 ### Job lifecycle
 
@@ -189,8 +194,8 @@ sequenceDiagram
 
 
 
-1. **on_create**: Operator validates the spec (cluster exists if specified, `exclusive` requires `cluster`). If `spec.shutdown` is set (`Stop` or `Terminate`), immediately sets `phase=Stopped`. Otherwise sets `phase=Resolving`.
-2. **timer (Resolving)**: Launches a Forge resolve K8s Job that patches the FournosJob spec with `hardware` (if not user-provided) and `secretRefs`. Polls the Job for completion. On success, reads the FournosJob spec, validates hardware (GPU type checked against Kueue), validates `secretRefs` against Vault secrets, creates the Kueue Workload (exclusive jobs request all 100 `fournos/cluster-slot` units; normal jobs request 1), and sets `phase=Pending`. Failed resolve Jobs are preserved for debugging.
+1. **on_create**: Operator validates the spec (cluster exists if specified, `exclusive` requires `cluster` — and `exclusive` defaults to `true`). If `spec.shutdown` is set (`Stop` or `Terminate`), immediately sets `phase=Stopped`. Otherwise sets `phase=Resolving`.
+2. **timer (Resolving)**: Launches a Forge resolve K8s Job that patches the FournosJob spec with `hardware` (if not user-provided) and `secretRefs`. Polls the Job for completion. On success, reads the FournosJob spec, validates hardware (GPU type checked against Kueue; hardware is optional for exclusive+cluster jobs), validates `secretRefs` against Vault secrets, creates the Kueue Workload (exclusive jobs request all 100 `fournos/cluster-slot` units; non-exclusive jobs request 1), and sets `phase=Pending`. Failed resolve Jobs are preserved for debugging.
 3. **timer (Pending)**: Polls the Workload for Kueue admission. On admission, extracts the assigned cluster and sets `phase=Admitted`.
 4. **timer (Admitted)**: Reads `secretRefs` from the FournosJob spec, copies each referenced secret from `secrets_namespace` into the operator namespace (per-job name `<fjob-name>-<ref>`, with `ownerReferences` for automatic cleanup), resolves the kubeconfig Secret, creates the Tekton PipelineRun with a projected `vault-secrets` volume mounting all copied secrets at `/var/run/secrets/fournos/<entry-name>/` and `ownerReferences` pointing at the FournosJob, sets `phase=Running`.
 5. **timer (Running)**: Polls the PipelineRun for completion. On success/failure, deletes the Workload and sets `phase=Succeeded` or `phase=Failed`.
@@ -379,9 +384,9 @@ dev/
   sample-job.yaml          # Example FournosJob CR for testing
 tests/
   conftest.py              # Fixtures (kubernetes client, helpers, cleanup)
-  test_scheduling.py       # Cluster pin, hardware, both, alt pipeline, inadmissible, wrong GPU, optional spec fields
-  test_validation.py       # Unknown cluster, admitted without flavor
-  test_resolving.py        # Resolving phase: happy paths, hardware precedence, Forge failures, GPU validation
+  test_scheduling.py       # Cluster pin, hardware, both, alt pipeline, inadmissible, wrong GPU, optional spec fields, default-exclusive slot count
+  test_validation.py       # Unknown cluster, admitted without flavor, implicit exclusive without cluster
+  test_resolving.py        # Resolving phase: happy paths, hardware precedence, Forge failures, GPU validation, non-exclusive cluster without hardware
   test_lifecycle.py        # Workload cleanup, delete cleanup, list, filter by phase
   test_resource_gc.py      # Stale Workload/PipelineRun garbage collection
   test_exclusive.py        # Exclusive cluster locking (happy path, blocking, occupancy, lock release)
@@ -407,7 +412,7 @@ README.md
 - **Timer-based reconciliation** — the operator polls Workload admission and PipelineRun completion via a kopf timer (5s interval), eliminating the need for callback tasks or watch streams on third-party resources
 - **Operator cleans up on completion** — Kueue Workloads are deleted when the PipelineRun reaches a terminal state, releasing quota without relying on external callbacks
 - **ownerReferences for cascade deletion** — Workloads, PipelineRuns, resolve Jobs, and copied secrets all carry `ownerReferences` pointing at their FournosJob, so Kubernetes automatically cascade-deletes them when the job is removed
-- **Exclusive locking via Kueue semaphore** — each cluster flavor has 100 `fournos/cluster-slot` units. Normal jobs request 1 slot; exclusive jobs request all 100. Kueue enforces mutual exclusion atomically — no operator-level blocking, labels, or in-memory state needed. Hardware-only jobs are automatically steered to clusters with available slots.
+- **Exclusive locking via Kueue semaphore** — each cluster flavor has 100 `fournos/cluster-slot` units. Non-exclusive jobs request 1 slot; exclusive jobs (the default) request all 100. Kueue enforces mutual exclusion atomically — no operator-level blocking, labels, or in-memory state needed. Hardware-only jobs are automatically steered to clusters with available slots. Exclusive jobs with a cluster may omit hardware — the Workload only needs cluster-slot resources for locking.
 - **Shutdown via spec field** — the `spec.shutdown` enum supports two modes: `Stop` (Tekton `CancelledRunFinally` — runs `finally` cleanup tasks) and `Terminate` (Tekton `Cancelled` — skips `finally` tasks). Both transition to an intermediate `Stopping` phase while the PipelineRun winds down. The Workload (and its quota) is kept alive until the PipelineRun completes, ensuring the cluster slot is not released prematurely. Only then does the operator delete the Workload and set `phase=Stopped`. The enum is extensible for future shutdown strategies. The FournosJob stays around in `Stopped` phase for inspection, unlike deletion which cascades and removes the record.
 - **Mandatory Resolving phase** — every job passes through a `Resolving` phase before entering `Pending`. During this phase, a Forge K8s Job runs to determine hardware requirements (`gpuType`, `gpuCount`) and secret references (`secretRefs`). Forge patches these values directly into the FournosJob spec (hardware only when not already user-provided). The operator validates them after the Job completes. Failed resolve Jobs are preserved for debugging.
 - **Vault-based secret management with cross-namespace injection** — pipeline secrets originate in a HashiCorp Vault and are synced to K8s Secrets on demand via `hacks/sync_vault_secrets.py` into a dedicated secrets namespace (`FOURNOS_SECRETS_NAMESPACE`, default `psap-secrets`). The K8s Secret name uses a `vault-` prefix followed by the Vault entry name (e.g. `vault-my-creds`); entries that are not valid DNS-1123 names are rejected during sync. Each synced Secret carries a `fournos.dev/vault-entry=true` label. Secret references are populated by Forge during the Resolving phase on `spec.secretRefs`. The operator validates them in the secrets namespace before creating the Workload (during Resolving). During the Admitted phase, the operator copies each referenced secret from the secrets namespace into the operator namespace with a per-job name (`<fjob-name>-<secret-name>`) and `ownerReferences` to the FournosJob for automatic cleanup. The copies are combined into a single projected volume (`vault-secrets`) mounted at `/var/run/secrets/fournos/<entry-name>/<key>`, with each secret's keys placed under a subdirectory matching its original name. This avoids key collisions across secrets and works with a static `volumeMount` in the Task YAML regardless of how many secrets a job uses. An empty projected volume (no secrets) is always emitted so the static mount never fails. Missing or non-vault refs fail the job during Resolving rather than creating a broken PipelineRun.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ oc delete FournosJob -n $FOURNOS_NAMESPACE <name>      # cleanup
 | `spec.forge.args` | yes | List of arguments passed to FORGE |
 | `spec.forge.configOverrides` | no | Arbitrary YAML overrides passed to the test framework |
 | `spec.env` | no | Environment variables passed to the pipeline as a `KEY=VALUE` env file |
-| `spec.cluster` | \* | Pin to a specific cluster (Kueue ResourceFlavor) |
+| `spec.cluster` | \* | Pin to a specific cluster (Kueue ResourceFlavor). Since `exclusive` defaults to `true`, this also locks the cluster — set `exclusive: false` for shared access. |
 | `spec.hardware.gpuType` | \* | Short GPU model name — e.g. `a100`, `h200`. The operator prepends the `FOURNOS_GPU_RESOURCE_PREFIX` (default `fournos/gpu-`) automatically, so do **not** include the full resource path. |
 | `spec.hardware.gpuCount` | with gpuType | Number of GPUs (minimum 1) |
 | `spec.owner` | no | Team or individual that owns this job |
@@ -86,14 +86,18 @@ oc delete FournosJob -n $FOURNOS_NAMESPACE <name>      # cleanup
 | `spec.pipeline` | no | Tekton Pipeline name (default: `fournos-full`) |
 | `spec.priority` | no | Kueue WorkloadPriorityClass name |
 | `spec.secretRefs` | no | Vault-synced K8s Secret names (prefixed with `vault-`) to mount into the pipeline. Populated by Forge during the Resolving phase. The operator validates each name in `FOURNOS_SECRETS_NAMESPACE`, copies the secrets into the operator namespace, and mounts them as a projected volume at `/var/run/secrets/fournos/<entry-name>/`. |
-| `spec.exclusive` | no | If `true`, locks the target cluster so no other FournosJob can run there. Requires `spec.cluster`. |
+| `spec.exclusive` | no (default `true`) | If `true`, locks the target cluster so no other FournosJob can run there. Requires `spec.cluster`. Hardware is optional — when omitted the Workload only requests cluster-slot resources for locking. |
 | `spec.shutdown` | no | Shutdown action: `Stop` cancels gracefully (Tekton `CancelledRunFinally` — runs `finally` tasks); `Terminate` cancels immediately (Tekton `Cancelled` — skips `finally` tasks). Both wait for the PipelineRun to finish before releasing Kueue quota. |
 
-\* `spec.cluster` and `spec.hardware` are both optional. Every job passes
-through the Resolving phase where Forge populates `spec.hardware` (if not
-already set) and `spec.secretRefs` directly on the FournosJob.
-`spec.cluster` can be set alongside `spec.hardware` to pin a hardware request
-to a specific cluster.
+\* `spec.hardware` is required unless the job uses exclusive cluster locking
+(`exclusive: true` + `cluster`), in which case it may be omitted — the
+Workload only needs cluster-slot resources. Every job passes through the
+Resolving phase where Forge populates `spec.hardware` (if not already set)
+and `spec.secretRefs` directly on the FournosJob. Since `exclusive` defaults
+to `true`, any job with `spec.cluster` locks the cluster exclusively —
+including jobs that also specify `spec.hardware`. Set `exclusive: false` for
+shared access (hardware is then required). Jobs without `spec.cluster` must
+set `exclusive: false`.
 
 ### Status
 

--- a/fournos/core/kueue.py
+++ b/fournos/core/kueue.py
@@ -36,7 +36,7 @@ class KueueClient:
         gpu_type: str | None = None,
         gpu_count: int = 0,
         cluster: str | None = None,
-        exclusive: bool = False,
+        exclusive: bool = True,
         priority: str | None = None,
         owner_ref: dict | None = None,
     ) -> dict:

--- a/fournos/handlers/lifecycle.py
+++ b/fournos/handlers/lifecycle.py
@@ -48,7 +48,7 @@ def on_create(spec, name, namespace, status, patch, body):
         return
 
     cluster = spec.get("cluster")
-    exclusive = spec.get("exclusive", False)
+    exclusive = spec["exclusive"]
 
     if exclusive and not cluster:
         patch.status["phase"] = Phase.FAILED
@@ -173,7 +173,7 @@ def reconcile_pending(spec, name, status, patch, body):
         new_msg, log_msg = _pending_status(
             wl_message,
             cluster,
-            spec.get("exclusive", False),
+            spec["exclusive"],
             locker,
         )
         if status.get("message") != new_msg:

--- a/fournos/handlers/resolving.py
+++ b/fournos/handlers/resolving.py
@@ -125,24 +125,38 @@ def _resolve_hardware(spec, name, conditions, patch):
     Forge populates ``spec.hardware`` when absent.  The GPU type is
     always validated against Kueue.
 
-    Returns ``(gpu_type, gpu_count)`` on success, or ``None`` if
-    validation failed (patch already set to Failed).
+    Exclusive jobs pinned to a cluster may omit hardware — the Workload
+    only needs cluster-slot resources for locking.
+
+    Returns ``(gpu_type, gpu_count)`` on success (gpu_type may be
+    ``None`` for exclusive-only), or ``None`` if validation failed
+    (patch already set to Failed).
     """
     hardware = spec.get("hardware") or {}
     gpu_type = hardware.get("gpuType")
     gpu_count = hardware.get("gpuCount", 0)
 
+    exclusive_lock = spec["exclusive"] and spec.get("cluster")
+
     if not gpu_type or not gpu_count:
-        _resolve_failed(
-            patch,
-            conditions,
+        if not exclusive_lock:
+            _resolve_failed(
+                patch,
+                conditions,
+                name,
+                "No hardware requirements: spec.hardware not populated "
+                "after Forge resolution",
+                reason="NoHardware",
+                cond_message="No hardware requirements found",
+            )
+            return None
+        logger.warning(
+            "Job %s: exclusive cluster lock without hardware — "
+            "Workload will only request cluster-slot resources "
+            "(Forge may not have populated spec.hardware)",
             name,
-            "No hardware requirements: spec.hardware not populated "
-            "after Forge resolution",
-            reason="NoHardware",
-            cond_message="No hardware requirements found",
         )
-        return None
+        return None, 0
 
     try:
         known_gpu_types = ctx.kueue.list_gpu_types()
@@ -218,7 +232,7 @@ def _create_workload_and_transition(
             gpu_type=gpu_type,
             gpu_count=gpu_count,
             cluster=spec.get("cluster"),
-            exclusive=spec.get("exclusive", False),
+            exclusive=spec["exclusive"],
             priority=spec.get("priority"),
             owner_ref=owner_ref(body),
         )

--- a/fournos/handlers/resolving.py
+++ b/fournos/handlers/resolving.py
@@ -128,7 +128,8 @@ def _resolve_hardware(
     """Determine and validate GPU requirements from the FournosJob spec.
 
     Forge populates ``spec.hardware`` when absent.  The GPU type is
-    always validated against Kueue.
+    validated against Kueue unless this is an exclusive cluster-lock
+    job with no hardware requirements.
 
     Exclusive jobs pinned to a cluster may omit hardware — the Workload
     only needs cluster-slot resources for locking.

--- a/fournos/handlers/resolving.py
+++ b/fournos/handlers/resolving.py
@@ -119,7 +119,12 @@ def _check_job_finished(job, name, conditions, patch):
     return True
 
 
-def _resolve_hardware(spec, name, conditions, patch):
+def _resolve_hardware(
+    spec,
+    name,
+    conditions,
+    patch,
+) -> tuple[str | None, int | None]:
     """Determine and validate GPU requirements from the FournosJob spec.
 
     Forge populates ``spec.hardware`` when absent.  The GPU type is
@@ -128,9 +133,11 @@ def _resolve_hardware(spec, name, conditions, patch):
     Exclusive jobs pinned to a cluster may omit hardware — the Workload
     only needs cluster-slot resources for locking.
 
-    Returns ``(gpu_type, gpu_count)`` on success (gpu_type may be
-    ``None`` for exclusive-only), or ``None`` if validation failed
-    (patch already set to Failed).
+    Returns:
+        (gpu_type, gpu_count): On success.  ``gpu_type`` is ``None``
+            and ``gpu_count`` is ``0`` for exclusive-only jobs.
+        (None, None): Validation failed; the patch has already been set
+            to ``Failed`` with a descriptive message.
     """
     hardware = spec.get("hardware") or {}
     gpu_type = hardware.get("gpuType")
@@ -149,7 +156,7 @@ def _resolve_hardware(spec, name, conditions, patch):
                 reason="NoHardware",
                 cond_message="No hardware requirements found",
             )
-            return None
+            return None, None
         logger.warning(
             "Job %s: exclusive cluster lock without hardware — "
             "Workload will only request cluster-slot resources "
@@ -169,7 +176,7 @@ def _resolve_hardware(spec, name, conditions, patch):
             reason="InvalidGPUType",
             cond_message=f"Kueue API error: {exc.reason}",
         )
-        return None
+        return None, None
     if not known_gpu_types:
         _resolve_failed(
             patch,
@@ -180,7 +187,7 @@ def _resolve_hardware(spec, name, conditions, patch):
             cond_message="No GPU types found in any ClusterQueue",
         )
         logger.error("Job %s: no GPU types found in any ClusterQueue", name)
-        return None
+        return None, None
     if gpu_type not in known_gpu_types:
         _resolve_failed(
             patch,
@@ -191,7 +198,7 @@ def _resolve_hardware(spec, name, conditions, patch):
             reason="InvalidGPUType",
             cond_message=f"GPU type '{gpu_type}' not available",
         )
-        return None
+        return None, None
 
     return gpu_type, gpu_count
 
@@ -291,14 +298,12 @@ def reconcile_resolving(spec, name, status, patch, body):
     if not _check_job_finished(job, name, conditions, patch):
         return
 
-    hw = _resolve_hardware(spec, name, conditions, patch)
-    if hw is None:
+    gpu_type, gpu_count = _resolve_hardware(spec, name, conditions, patch)
+    if gpu_count is None:
         return
 
     if not _validate_secret_refs(spec, name, conditions, patch):
         return
-
-    gpu_type, gpu_count = hw
     _create_workload_and_transition(
         spec, name, conditions, patch, body, gpu_type, gpu_count
     )

--- a/fournos/handlers/status.py
+++ b/fournos/handlers/status.py
@@ -70,7 +70,7 @@ def create_workload_for_job(spec, name, body):
         gpu_type=hardware.get("gpuType") if hardware else None,
         gpu_count=hardware.get("gpuCount", 0) if hardware else 0,
         cluster=spec.get("cluster"),
-        exclusive=spec.get("exclusive", False),
+        exclusive=spec["exclusive"],
         priority=spec.get("priority"),
         owner_ref=owner_ref(body),
     )

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -117,12 +117,14 @@ spec:
                     type: string
                 exclusive:
                   type: boolean
-                  default: false
+                  default: true
                   description: >-
                     Lock the target cluster for exclusive use by this job.
                     When true, the job waits until the cluster has no other active
                     jobs and then prevents any new job from being scheduled there.
-                    Requires 'cluster' to be set.
+                    Requires 'cluster' to be set.  Hardware is optional — when
+                    omitted the Workload only requests cluster-slot resources
+                    for locking.
                 priority:
                   type: string
                 shutdown:

--- a/tests/test_exclusive.py
+++ b/tests/test_exclusive.py
@@ -13,8 +13,11 @@ from fournos.core.constants import MAX_CLUSTER_SLOTS, Phase
 from tests.conftest import (
     NAMESPACE,
     create_job,
+    create_noop_resolve_job,
     get_job,
     get_workload_cluster_slots,
+    get_workload_gpu_request,
+    get_workload_node_selector,
     job_status_summary,
     poll_phase,
     workload_exists,
@@ -127,6 +130,7 @@ def test_normal_workload_requests_one_slot(k8s):
         k8s,
         "test-normal-slots",
         {
+            "exclusive": False,
             "cluster": "cluster-1",
             "forge": {"project": "testproj/llmd", "args": ["cks", "internal-test"]},
         },
@@ -159,6 +163,7 @@ def test_exclusive_blocks_cluster_pinned_job(k8s):
         k8s,
         "test-blocked-pin",
         {
+            "exclusive": False,
             "cluster": "cluster-2",
             "forge": {"project": "testproj/llmd", "args": ["cks", "internal-test"]},
         },
@@ -215,6 +220,7 @@ def test_exclusive_steers_hardware_only_job(k8s):
         k8s,
         "test-hw-avoid",
         {
+            "exclusive": False,
             "hardware": {"gpuType": "a100", "gpuCount": 2},
             "forge": {"project": "testproj/llmd", "args": ["cks", "internal-test"]},
         },
@@ -268,6 +274,7 @@ def test_exclusive_waits_for_cluster_to_clear(k8s):
         k8s,
         "test-occupant",
         {
+            "exclusive": False,
             "cluster": "cluster-2",
             "forge": {"project": "testproj/llmd", "args": ["cks", "internal-test"]},
         },
@@ -329,6 +336,7 @@ def test_lock_released_on_completion(k8s):
         k8s,
         "test-waiting",
         {
+            "exclusive": False,
             "cluster": "cluster-1",
             "forge": {"project": "testproj/llmd", "args": ["cks", "internal-test"]},
         },
@@ -363,3 +371,57 @@ def test_lock_released_on_completion(k8s):
         timeout=60,
     )
     assert phase == Phase.SUCCEEDED, job_status_summary(k8s, "test-waiting")
+
+
+def test_exclusive_without_hardware(k8s):
+    """Exclusive + cluster without hardware: locks cluster using only cluster-slot resources.
+
+    A noop resolve Job prevents Forge from populating hardware.  The
+    Workload should carry 100 cluster-slots and a nodeSelector but no
+    GPU resource requests.
+    """
+    create_noop_resolve_job("test-excl-nohw")
+
+    create_job(
+        k8s,
+        "test-excl-nohw",
+        {
+            "cluster": "cluster-2",
+            "exclusive": True,
+            "forge": {"project": "testproj/llmd", "args": ["cks", "internal-test"]},
+        },
+    )
+
+    poll_phase(
+        k8s,
+        "test-excl-nohw",
+        terminal={Phase.PENDING, Phase.ADMITTED, Phase.RUNNING},
+        timeout=45,
+    )
+
+    slots = get_workload_cluster_slots("test-excl-nohw")
+    assert slots == MAX_CLUSTER_SLOTS, (
+        f"Exclusive Workload should request {MAX_CLUSTER_SLOTS} slots, got {slots}"
+    )
+
+    ns = get_workload_node_selector("test-excl-nohw")
+    assert ns == {"fournos.dev/cluster": "cluster-2"}, (
+        f"Workload nodeSelector should pin to cluster-2, got {ns}"
+    )
+
+    a100 = get_workload_gpu_request("test-excl-nohw", "a100")
+    h200 = get_workload_gpu_request("test-excl-nohw", "h200")
+    assert a100 == 0 and h200 == 0, (
+        f"Workload should have no GPU requests, got a100={a100}, h200={h200}"
+    )
+
+    phase = poll_phase(
+        k8s,
+        "test-excl-nohw",
+        terminal={Phase.SUCCEEDED, Phase.FAILED},
+        timeout=90,
+    )
+    assert phase == Phase.SUCCEEDED, job_status_summary(k8s, "test-excl-nohw")
+
+    job = get_job(k8s, "test-excl-nohw")
+    assert job["status"]["cluster"] == "cluster-2"

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -131,6 +131,7 @@ def test_filter_jobs_by_phase(k8s):
         k8s,
         "test-filter-stuck",
         {
+            "exclusive": False,
             "hardware": {"gpuType": "a100", "gpuCount": 100},
             "forge": {"project": "testproj/llmd", "args": ["cks", "internal-test"]},
         },

--- a/tests/test_resolving.py
+++ b/tests/test_resolving.py
@@ -93,6 +93,7 @@ def test_happy_path_without_hardware(k8s):
         k8s,
         "test-resolve-nohw",
         {
+            "exclusive": False,
             "forge": {"project": "testproj/llmd", "args": ["cks", "internal-test"]},
         },
     )
@@ -237,6 +238,7 @@ def test_unknown_gpu_type(k8s):
         k8s,
         "test-bad-gpu",
         {
+            "exclusive": False,
             "hardware": {"gpuType": "acbd1234", "gpuCount": 2},
             "forge": {"project": "testproj/llmd", "args": ["cks", "internal-test"]},
         },
@@ -306,6 +308,42 @@ def test_resolve_job_failure(k8s):
     )
 
 
+def test_nonexclusive_cluster_without_hardware_fails(k8s):
+    """Non-exclusive + cluster + no hardware → Failed (hardware required).
+
+    A noop resolve Job prevents Forge from populating hardware.  Since
+    the job is non-exclusive, the missing hardware is not allowed (only
+    exclusive+cluster jobs may omit it).
+    """
+    create_noop_resolve_job("test-nex-nohw")
+
+    create_job(
+        k8s,
+        "test-nex-nohw",
+        {
+            "exclusive": False,
+            "cluster": "cluster-1",
+            "forge": {"project": "testproj/llmd", "args": ["cks", "internal-test"]},
+        },
+    )
+
+    phase = poll_phase(
+        k8s,
+        "test-nex-nohw",
+        terminal={Phase.FAILED},
+        message_substring="No hardware requirements",
+        timeout=45,
+    )
+    assert phase == Phase.FAILED, job_status_summary(k8s, "test-nex-nohw")
+
+    conditions = {
+        c["type"]: c
+        for c in get_job(k8s, "test-nex-nohw")["status"].get("conditions", [])
+    }
+    assert conditions["Resolved"]["status"] == "False"
+    assert conditions["Resolved"]["reason"] == "NoHardware"
+
+
 def test_resolve_empty_hw(k8s):
     """Resolve Job succeeds but doesn't populate spec.hardware -> Failed.
 
@@ -319,6 +357,7 @@ def test_resolve_empty_hw(k8s):
         k8s,
         "test-resolve-noconfig",
         {
+            "exclusive": False,
             "forge": {"project": "testproj/llmd", "args": ["cks", "internal-test"]},
         },
     )

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -2,14 +2,16 @@
 
 import yaml
 
-from fournos.core.constants import Phase
+from fournos.core.constants import MAX_CLUSTER_SLOTS, Phase
 from tests.conftest import (
     NAMESPACE,
     create_job,
     get_job,
     get_k8s_resource,
     get_pipelinerun_param,
+    get_workload_cluster_slots,
     get_workload_flavor,
+    get_workload_gpu_request,
     get_workload_node_selector,
     job_status_summary,
     poll_phase,
@@ -86,6 +88,7 @@ def test_hardware_request(k8s):
         k8s,
         "test-hardware",
         {
+            "exclusive": False,
             "hardware": {"gpuType": "a100", "gpuCount": 2},
             "forge": {"project": "testproj/llmd", "args": ["llama3", "internal-test"]},
             "priority": "nightly",
@@ -131,6 +134,10 @@ def test_cluster_and_hardware(k8s):
     assert ns == {"fournos.dev/cluster": "cluster-4"}, (
         f"Workload nodeSelector should pin to cluster-4, got {ns}"
     )
+    slots = get_workload_cluster_slots("test-cluster-hw")
+    assert slots == MAX_CLUSTER_SLOTS, (
+        f"Default-exclusive cluster+hw job should request {MAX_CLUSTER_SLOTS} slots, got {slots}"
+    )
     flavor = get_workload_flavor("test-cluster-hw")
     assert flavor == "cluster-4", f"Workload flavor should be cluster-4, got {flavor!r}"
     secret = get_pipelinerun_param("test-cluster-hw", "kubeconfig-secret")
@@ -150,6 +157,46 @@ def test_cluster_and_hardware(k8s):
     assert job["status"]["cluster"] == "cluster-4", (
         f"Expected cluster cluster-4, got {job['status'].get('cluster')!r}"
     )
+
+
+def test_shared_cluster_with_hardware(k8s):
+    """Shared access (exclusive: false) + cluster + hardware: 1 slot + GPU request."""
+    create_job(
+        k8s,
+        "test-shared-hw",
+        {
+            "exclusive": False,
+            "cluster": "cluster-3",
+            "hardware": {"gpuType": "h200", "gpuCount": 4},
+            "forge": {"project": "testproj/llmd", "args": ["cks", "internal-test"]},
+        },
+    )
+
+    poll_phase(
+        k8s,
+        "test-shared-hw",
+        terminal={Phase.RUNNING, Phase.SUCCEEDED, Phase.FAILED},
+        timeout=30,
+    )
+
+    slots = get_workload_cluster_slots("test-shared-hw")
+    assert slots == 1, f"Non-exclusive Workload should request 1 slot, got {slots}"
+
+    gpu_req = get_workload_gpu_request("test-shared-hw", "h200")
+    assert gpu_req == 4, f"Workload should request 4 H200 GPUs, got {gpu_req}"
+
+    ns = get_workload_node_selector("test-shared-hw")
+    assert ns == {"fournos.dev/cluster": "cluster-3"}, (
+        f"Workload nodeSelector should pin to cluster-3, got {ns}"
+    )
+
+    phase = poll_phase(
+        k8s,
+        "test-shared-hw",
+        terminal={Phase.SUCCEEDED, Phase.FAILED},
+        timeout=60,
+    )
+    assert phase == Phase.SUCCEEDED, job_status_summary(k8s, "test-shared-hw")
 
 
 def test_alternative_pipeline_selection(k8s):
@@ -185,6 +232,7 @@ def test_inadmissible_stays_pending(k8s):
         k8s,
         "test-inadmissible",
         {
+            "exclusive": False,
             "hardware": {"gpuType": "a100", "gpuCount": 100},
             "forge": {"project": "testproj/llmd", "args": ["cks", "internal-test"]},
         },

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -41,6 +41,7 @@ def test_stop_pending_job(k8s):
         k8s,
         "test-stop-pending",
         {
+            "exclusive": False,
             "hardware": {"gpuType": "a100", "gpuCount": 100},
             "forge": {"project": "testproj/llmd", "args": ["cks", "internal-test"]},
         },

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -52,6 +52,7 @@ def test_admitted_without_flavor(k8s):
         k8s,
         "test-no-flavor",
         {
+            "exclusive": False,
             "hardware": {"gpuType": "a100", "gpuCount": 999},
             "forge": {"project": "testproj/llmd", "args": ["cks", "internal-test"]},
         },
@@ -118,3 +119,29 @@ def test_admitted_without_flavor(k8s):
     )
 
     poll_resource_gone(workload_exists, "test-no-flavor")
+
+
+def test_implicit_exclusive_without_cluster_fails(k8s):
+    """Hardware-only job (no cluster, no explicit exclusive) fails: CRD defaults exclusive to true."""
+    create_job(
+        k8s,
+        "test-implicit-excl",
+        {
+            "hardware": {"gpuType": "a100", "gpuCount": 2},
+            "forge": {"project": "testproj/llmd", "args": ["cks", "internal-test"]},
+        },
+    )
+
+    phase = poll_phase(
+        k8s,
+        "test-implicit-excl",
+        terminal={Phase.FAILED},
+        timeout=15,
+    )
+    assert phase == Phase.FAILED, job_status_summary(k8s, "test-implicit-excl")
+
+    job = get_job(k8s, "test-implicit-excl")
+    msg = job["status"]["message"].lower()
+    assert "cluster" in msg and "exclusive" in msg, (
+        f"Failure message should mention both 'exclusive' and 'cluster', got: {msg!r}"
+    )


### PR DESCRIPTION
Closes https://github.com/openshift-psap/fournos/issues/67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exclusive cluster locking is now the default; set `exclusive: false` to allow shared cluster access.
  * When exclusively locking a cluster, hardware becomes optional (cluster-slot-only runs supported).

* **Bug Fixes / Behavior Changes**
  * Jobs must now include `exclusive` (omitting it may cause validation failures); non-exclusive jobs continue to require hardware.

* **Documentation**
  * Design doc and README updated to clarify new scheduling semantics and requirements.

* **Tests**
  * Added and updated tests covering exclusive/non-exclusive and hardware scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->