### PR TITLE
Replace individual FORGE params with FJOB_NAME + FOURNOS_NAMESPACE

### DIFF
--- a/Fournos_Design_Document.md
+++ b/Fournos_Design_Document.md
@@ -47,7 +47,7 @@ Jobs are submitted as `FournosJob` custom resources ([manifests/crd.yaml](manife
 | `spec.forge.project`         | yes          | FORGE project path                                                                               |
 | `spec.forge.args`            | yes          | List of arguments passed to FORGE                                                                |
 | `spec.forge.configOverrides` | no           | Arbitrary YAML overrides passed to the test framework                                            |
-| `spec.env`                   | no           | Environment variables passed to the pipeline as a `KEY=VALUE` env file                           |
+| `spec.env`                   | no           | Environment variables available to FORGE (read from the FournosJob spec via K8s API)             |
 | `spec.cluster`               |              | Pin to a specific cluster (Kueue ResourceFlavor). Since `exclusive` defaults to `true`, this also locks the cluster — set `exclusive: false` for shared access. |
 | `spec.hardware.gpuType`      |              | Short GPU model name (e.g. `a100`, `h200`). The operator adds the resource prefix automatically. |
 | `spec.hardware.gpuCount`     | with gpuType | Number of GPUs (minimum 1)                                                                       |
@@ -62,7 +62,7 @@ Jobs are submitted as `FournosJob` custom resources ([manifests/crd.yaml](manife
 
 `spec.hardware` is required unless the job uses exclusive cluster locking (`exclusive: true` + `cluster`), in which case it may be omitted — the Workload only needs cluster-slot resources. Every job passes through the mandatory Resolving phase where Forge populates `spec.hardware` (if not already set) and `spec.secretRefs` directly on the FournosJob. Since `exclusive` defaults to `true`, any job with `spec.cluster` locks the cluster exclusively — including jobs that also specify `spec.hardware`. Set `exclusive: false` for shared access. Jobs without `spec.cluster` must set `exclusive: false`.
 
-`metadata.name` is the unique identifier for the job. Use `metadata.generateName` for auto-generated unique names (e.g. `generateName: nightly-benchmark-` produces `nightly-benchmark-x7k2m`). `spec.displayName` is a human-readable label for external correlation — it does not need to be unique and is passed to the pipeline as `job-name`.
+`metadata.name` is the unique identifier for the job. Use `metadata.generateName` for auto-generated unique names (e.g. `generateName: nightly-benchmark-` produces `nightly-benchmark-x7k2m`). `spec.displayName` is a human-readable label for external correlation — it does not need to be unique. FORGE reads it directly from the FournosJob spec via the K8s API.
 
 ### Status
 
@@ -197,7 +197,7 @@ sequenceDiagram
 1. **on_create**: Operator validates the spec (cluster exists if specified, `exclusive` requires `cluster` — and `exclusive` defaults to `true`). If `spec.shutdown` is set (`Stop` or `Terminate`), immediately sets `phase=Stopped`. Otherwise sets `phase=Resolving`.
 2. **timer (Resolving)**: Launches a Forge resolve K8s Job that patches the FournosJob spec with `hardware` (if not user-provided) and `secretRefs`. Polls the Job for completion. On success, reads the FournosJob spec, validates hardware (GPU type checked against Kueue; hardware is optional for exclusive+cluster jobs), validates `secretRefs` against Vault secrets, creates the Kueue Workload (exclusive jobs request all 100 `fournos/cluster-slot` units; non-exclusive jobs request 1), and sets `phase=Pending`. Failed resolve Jobs are preserved for debugging.
 3. **timer (Pending)**: Polls the Workload for Kueue admission. On admission, extracts the assigned cluster and sets `phase=Admitted`.
-4. **timer (Admitted)**: Reads `secretRefs` from the FournosJob spec, copies each referenced secret from `secrets_namespace` into the operator namespace (per-job name `<fjob-name>-<ref>`, with `ownerReferences` for automatic cleanup), resolves the kubeconfig Secret, creates the Tekton PipelineRun with a projected `vault-secrets` volume mounting all copied secrets at `/var/run/secrets/fournos/<entry-name>/` and `ownerReferences` pointing at the FournosJob, sets `phase=Running`.
+4. **timer (Admitted)**: Reads `secretRefs` from the FournosJob spec, copies each referenced secret from `secrets_namespace` into the operator namespace (per-job name `<fjob-name>-<ref>`, with `ownerReferences` for automatic cleanup), resolves the kubeconfig Secret, creates the Tekton PipelineRun with `FJOB_NAME` + `FOURNOS_NAMESPACE` params (so FORGE can look up the full spec), a projected `vault-secrets` volume mounting all copied secrets at `/var/run/secrets/fournos/<entry-name>/`, and `ownerReferences` pointing at the FournosJob, sets `phase=Running`.
 5. **timer (Running)**: Polls the PipelineRun for completion. On success/failure, deletes the Workload and sets `phase=Succeeded` or `phase=Failed`.
 6. **timer (any non-terminal phase, shutdown)**: If `spec.shutdown` is set (`Stop` or `Terminate`) and the job has a PipelineRun (Admitted/Running), the timer cancels the PipelineRun — `Stop` uses Tekton's `CancelledRunFinally` (runs `finally` tasks), `Terminate` uses `Cancelled` (skips `finally` tasks) — and sets `phase=Stopping`. The Workload is **not** deleted yet — it stays alive to hold the cluster slot while the PipelineRun winds down. If no PipelineRun exists (Pending), the Workload is deleted immediately and the job goes straight to `phase=Stopped`.
 7. **timer (Stopping)**: Polls the PipelineRun until it reaches a terminal state (`succeeded` or `failed`). Once complete, deletes the Workload to release Kueue quota and sets `phase=Stopped`.
@@ -256,14 +256,14 @@ The operator is stateless and crash-safe. On restart, `@kopf.on.resume` re-evalu
 
 FORGE is an existing benchmark execution framework that runs on the hub cluster inside Tekton Task pods and owns all operations on target clusters — setup, benchmark execution, and cleanup — by issuing remote `oc`/`kubectl` commands via kubeconfig Secrets. Fournos has a strict separation of concerns: it handles cluster selection, scheduling, and bookkeeping, but never interacts with target clusters directly.
 
-The operator passes FORGE configuration to the Tekton Pipeline as two params:
+Instead of extracting individual fields from the FournosJob spec and passing them as separate pipeline params, the operator passes two identifiers to both the resolve Job and the Tekton Pipeline:
 
-- **`forge-project`** — `spec.forge.project` as a plain string, for direct use in task scripts (e.g. `bin/run_ci "$(params.forge-project)" ci "$FOURNOS_STEP"`)
-- **`forge-config`** — the entire `spec.forge` dict serialized as YAML, written to `forge_config.yaml` in the task for FORGE to consume
+- **`FJOB_NAME`** — the FournosJob `metadata.name`
+- **`FOURNOS_NAMESPACE`** — the operator namespace
 
-Environment variables (`spec.env`) are serialized as `KEY=VALUE` lines and passed as the `env` param. Tasks write this to `forge_config.env` and source it before invoking FORGE.
+FORGE uses these to look up the full FournosJob spec via the Kubernetes API, giving it access to all configuration in one go (`spec.forge`, `spec.env`, etc.) without the operator needing to serialize and forward individual fields.
 
-Fournos also passes `job-name` (from `spec.displayName` or `metadata.name`) so FORGE can use it for its own resource naming and correlation.
+FORGE reads `spec.displayName` (or `metadata.name`) directly from the FournosJob spec for its own resource naming and correlation.
 
 **Hub configuration vs mocks:** `config/forge/` is the authoritative layout for deploying FORGE on the hub (workflows, images, samples). Tasks in `config/forge/workflows/tasks.yaml` and `config/fournos-validation/workflows/tasks.yaml` implement the parameter interface for real clusters. `dev/mock-pipelines/` holds echo/sleep Tekton stand-ins used only by kind-based dev setup and tests—not a substitute for `config/forge/`.
 
@@ -406,7 +406,7 @@ README.md
 - **CRD-based operator** (kopf) — consumers interact via `kubectl` / Kubernetes API, getting RBAC, audit logging, and `kubectl wait` for free
 - **Unified Kueue scheduling** — all jobs flow through Kueue for consistent quota tracking and priority ordering. Cluster-pinned jobs use `nodeSelector` to constrain admission to a single ResourceFlavor; hardware-request jobs leave all flavors eligible.
 - **Separation of concerns** — Fournos owns scheduling, bookkeeping, and parameter passing; FORGE owns all target-cluster operations (setup, execution, cleanup). Fournos never touches target clusters directly.
-- **FORGE is opaque** — Fournos never validates FORGE config; the entire `spec.forge` dict is serialized as YAML and passed through to the Tekton Pipeline alongside `spec.forge.project` as a convenience string param
+- **FORGE is opaque** — Fournos never validates FORGE config; it passes `FJOB_NAME` and `FOURNOS_NAMESPACE` so FORGE can look up the full FournosJob spec via the K8s API
 - **Tekton for execution, Kueue for scheduling** — virtual Workload pattern with `fournos/gpu-`* resources
 - **Stateless operator** — all job state lives in Kubernetes resources (FournosJob CRs, PipelineRuns, Workloads), not in memory. Crash-safe via `on_resume`.
 - **Timer-based reconciliation** — the operator polls Workload admission and PipelineRun completion via a kopf timer (5s interval), eliminating the need for callback tasks or watch streams on third-party resources

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ oc delete FournosJob -n $FOURNOS_NAMESPACE <name>      # cleanup
 | `spec.forge.project` | yes | FORGE project path |
 | `spec.forge.args` | yes | List of arguments passed to FORGE |
 | `spec.forge.configOverrides` | no | Arbitrary YAML overrides passed to the test framework |
-| `spec.env` | no | Environment variables passed to the pipeline as a `KEY=VALUE` env file |
+| `spec.env` | no | Environment variables available to FORGE (read from the FournosJob spec via K8s API) |
 | `spec.cluster` | \* | Pin to a specific cluster (Kueue ResourceFlavor). Since `exclusive` defaults to `true`, this also locks the cluster — set `exclusive: false` for shared access. |
 | `spec.hardware.gpuType` | \* | Short GPU model name — e.g. `a100`, `h200`. The operator prepends the `FOURNOS_GPU_RESOURCE_PREFIX` (default `fournos/gpu-`) automatically, so do **not** include the full resource path. |
 | `spec.hardware.gpuCount` | with gpuType | Number of GPUs (minimum 1) |
@@ -324,7 +324,7 @@ The operator runs as a single-replica Deployment using
 1. **Resolves** job requirements by launching a Forge K8s Job that populates the FournosJob spec with GPU type/count and secret references
 2. **Creates** a Kueue Workload with the resolved GPU resources (owned by the FournosJob via `ownerReferences`)
 3. **Polls** (5 s timer) for Kueue admission and assigned cluster
-4. **Copies** referenced Vault secrets from the secrets namespace into the operator namespace (per-job copies with `ownerReferences` for automatic cleanup) and **launches** a Tekton PipelineRun with FORGE parameters and the secrets mounted as a projected volume at `/var/run/secrets/fournos/` (owned by the FournosJob via `ownerReferences`)
+4. **Copies** referenced Vault secrets from the secrets namespace into the operator namespace (per-job copies with `ownerReferences` for automatic cleanup) and **launches** a Tekton PipelineRun with `FJOB_NAME` + `FOURNOS_NAMESPACE` (so FORGE can look up the full FournosJob spec) and the secrets mounted as a projected volume at `/var/run/secrets/fournos/` (owned by the FournosJob via `ownerReferences`)
 5. **Watches** the PipelineRun until completion
 6. **Deletes** the Workload to release Kueue quota
 

--- a/config/forge/resolve_job.yaml
+++ b/config/forge/resolve_job.yaml
@@ -19,13 +19,12 @@ spec:
         - name: resolve
           imagePullPolicy: Always
           env:
-            - name: FOURNOS_JOB_NAME
+            - name: FJOB_NAME
             - name: FOURNOS_NAMESPACE
-            - name: FORGE_PROJECT
-            - name: FORGE_CONFIG
-            - name: FOURNOS_ENV
             - name: FOURNOS_STEP
               value: resolve-fournos-config
+            - name: FOURNOS_CI
+              value: "true"
           command: ["/bin/bash", "-c"]
           args:
             - |
@@ -39,20 +38,24 @@ spec:
 
               exec &> >(tee -a "$ARTIFACT_DIR/run.log")
 
-              cat > $ARTIFACT_DIR/forge_config.yaml <<< "$FORGE_CONFIG"
+              oc get "fjob/$FJOB_NAME" -n "$FOURNOS_NAMESPACE" -oyaml > $ARTIFACT_DIR/fournos_fjob.yaml
 
-              cat > $ARTIFACT_DIR/forge_config.env <<< "$FOURNOS_ENV"
-
-              if grep -q '^PULL_BASE_SHA=' $ARTIFACT_DIR/forge_config.env; then
-                export PULL_BASE_SHA=$(cat $ARTIFACT_DIR/forge_config.env | grep '^PULL_BASE_SHA=' | cut -d'=' -f2)
+              PULL_BASE_SHA=$(cat "$ARTIFACT_DIR/fournos_fjob.yaml" | yq -r .spec.env.PULL_BASE_SHA)
+              if [[ "$PULL_BASE_SHA" != null ]]; then
+                export PULL_BASE_SHA
+              else
+                unset PULL_BASE_SHA
               fi
 
-              if grep -q '^PULL_PULL_SHA=' $ARTIFACT_DIR/forge_config.env; then
-                export PULL_PULL_SHA=$(cat $ARTIFACT_DIR/forge_config.env | grep '^PULL_PULL_SHA=' | cut -d'=' -f2)
+              PULL_PULL_SHA=$(cat "$ARTIFACT_DIR/fournos_fjob.yaml" | yq -r .spec.env.PULL_PULL_SHA)
+              if [[ "$PULL_PULL_SHA" != null ]]; then
+                export PULL_PULL_SHA
+              else
+                unset PULL_PULL_SHA
               fi
 
               if [[ "${PULL_PULL_SHA:-}" ]]; then
-              echo
+                echo
                 echo "Updating to PULL_PULL_SHA=$PULL_PULL_SHA ..."
 
                 git -C "$FORGE_HOME" fetch --quiet origin "$PULL_PULL_SHA"
@@ -60,8 +63,13 @@ spec:
               else
                 echo "No PULL_PULL_SHA, using the image commit"
               fi
-
               git show --quiet
+
+              FORGE_PROJECT=$(cat "$ARTIFACT_DIR/fournos_fjob.yaml" | yq -r .spec.forge.project)
+              if [[ -z "$FORGE_PROJECT" || "$FORGE_PROJECT" == null ]]; then
+                echo "ERROR: invalid .spec.forge.project='$FORGE_PROJECT' in $FOURNOS_NAMESPACE/$FJOB_NAME"
+                exit 1
+              fi
 
               export FOURNOS_CI=true
 

--- a/config/forge/workflows/pipeline-full.yaml
+++ b/config/forge/workflows/pipeline-full.yaml
@@ -5,45 +5,24 @@ metadata:
   name: forge-full
 spec:
   params:
-    - name: job-name
+    - name: fjob-name
       type: string
-    - name: forge-project
+    - name: fournos-namespace
       type: string
-    - name: forge-config
-      type: string
-    - name: env
-      type: string
-      default: ""
     - name: kubeconfig-secret
       type: string
-    - name: gpu-count
-      type: string
-    - name: secret-refs
-      type: array
-      default: []
 
   tasks:
     - name: pre-cleanup
       taskRef:
         name: forge-step
       params:
-        # -- common params -- #
-        - name: forge-project
-          value: "$(params.forge-project)"
-        - name: forge-config
-          value: "$(params.forge-config)"
-        - name: env
-          value: "$(params.env)"
+        - name: fjob-name
+          value: "$(params.fjob-name)"
+        - name: fournos-namespace
+          value: "$(params.fournos-namespace)"
         - name: kubeconfig-secret
           value: "$(params.kubeconfig-secret)"
-        - name: gpu-count
-          value: "$(params.gpu-count)"
-        - name: job-name
-          value: "$(params.job-name)"
-        - name: secret-refs
-          value:
-          - $(params.secret-refs[*])
-          # -- specific params -- #
         - name: job-step
           value: pre-cleanup
 
@@ -51,23 +30,12 @@ spec:
       taskRef:
         name: forge-step
       params:
-        # -- common params -- #
-        - name: forge-project
-          value: "$(params.forge-project)"
-        - name: forge-config
-          value: "$(params.forge-config)"
-        - name: env
-          value: "$(params.env)"
+        - name: fjob-name
+          value: "$(params.fjob-name)"
+        - name: fournos-namespace
+          value: "$(params.fournos-namespace)"
         - name: kubeconfig-secret
           value: "$(params.kubeconfig-secret)"
-        - name: gpu-count
-          value: "$(params.gpu-count)"
-        - name: job-name
-          value: "$(params.job-name)"
-        - name: secret-refs
-          value:
-          - $(params.secret-refs[*])
-          # -- specific params -- #
         - name: job-step
           value: prepare
 
@@ -76,23 +44,12 @@ spec:
       taskRef:
         name: forge-step
       params:
-        # -- common params -- #
-        - name: forge-project
-          value: "$(params.forge-project)"
-        - name: forge-config
-          value: "$(params.forge-config)"
-        - name: env
-          value: "$(params.env)"
+        - name: fjob-name
+          value: "$(params.fjob-name)"
+        - name: fournos-namespace
+          value: "$(params.fournos-namespace)"
         - name: kubeconfig-secret
           value: "$(params.kubeconfig-secret)"
-        - name: gpu-count
-          value: "$(params.gpu-count)"
-        - name: job-name
-          value: "$(params.job-name)"
-        - name: secret-refs
-          value:
-          - $(params.secret-refs[*])
-        # -- specific params -- #
         - name: job-step
           value: test
 
@@ -101,22 +58,11 @@ spec:
       taskRef:
         name: forge-step
       params:
-        # -- common params -- #
-        - name: forge-project
-          value: "$(params.forge-project)"
-        - name: forge-config
-          value: "$(params.forge-config)"
-        - name: env
-          value: "$(params.env)"
+        - name: fjob-name
+          value: "$(params.fjob-name)"
+        - name: fournos-namespace
+          value: "$(params.fournos-namespace)"
         - name: kubeconfig-secret
           value: "$(params.kubeconfig-secret)"
-        - name: gpu-count
-          value: "$(params.gpu-count)"
-        - name: job-name
-          value: "$(params.job-name)"
-        - name: secret-refs
-          value:
-          - $(params.secret-refs[*])
-        # -- specific params -- #
         - name: job-step
           value: pre-cleanup # there's currently no post-cleanup step

--- a/config/forge/workflows/pipeline-test-only.yaml
+++ b/config/forge/workflows/pipeline-test-only.yaml
@@ -6,42 +6,22 @@ metadata:
   name: forge-test-only
 spec:
   params:
-    - name: job-name
+    - name: fjob-name
       type: string
-    - name: forge-project
+    - name: fournos-namespace
       type: string
-    - name: forge-config
-      type: string
-    - name: env
-      type: string
-      default: ""
     - name: kubeconfig-secret
       type: string
-    - name: gpu-count
-      type: string
-    - name: secret-refs
-      type: array
-      default: []
   tasks:
     - name: test
       taskRef:
         name: forge-step
       params:
-        - name: forge-project
-          value: "$(params.forge-project)"
-        - name: forge-config
-          value: "$(params.forge-config)"
-        - name: env
-          value: "$(params.env)"
+        - name: fjob-name
+          value: "$(params.fjob-name)"
+        - name: fournos-namespace
+          value: "$(params.fournos-namespace)"
         - name: kubeconfig-secret
           value: "$(params.kubeconfig-secret)"
-        - name: gpu-count
-          value: "$(params.gpu-count)"
-        - name: job-name
-          value: "$(params.job-name)"
-        - name: secret-refs
-          value:
-          - $(params.secret-refs[*])
-
         - name: job-step
           value: "test"

--- a/config/forge/workflows/tasks.yaml
+++ b/config/forge/workflows/tasks.yaml
@@ -4,22 +4,14 @@ metadata:
   name: forge-step
 spec:
   params:
-    - name: forge-project
+    - name: fjob-name
       type: string
-    - name: forge-config
-      type: string
-    - name: env
+    - name: fournos-namespace
       type: string
     - name: kubeconfig-secret
       type: string
-    - name: gpu-count
-      type: string
-    - name: job-name
-      type: string
     - name: job-step
       type: string
-    - name: secret-refs
-      type: array
   steps:
     - name: forge
       image: image-registry.openshift-image-registry.svc:5000/$(context.taskRun.namespace)/forge-core:main
@@ -27,14 +19,16 @@ spec:
       env:
       - name: KUBECONFIG
         value: /var/run/secrets/fournos-kubeconfig/kubeconfig
-      - name: FORGE_CONFIG
-        value: "$(params.forge-config)"
-      - name: FOURNOS_ENV
-        value: "$(params.env)"
+      - name: FJOB_NAME
+        value: "$(params.fjob-name)"
+      - name: FOURNOS_NAMESPACE
+        value: "$(params.fournos-namespace)"
       - name: FOURNOS_STEP
         value: "$(params.job-step)"
       - name: FOURNOS_SECRETS
         value: /var/run/secrets/fournos
+      - name: FOURNOS_CI
+        value: "true"
       volumeMounts:
         - name: kubeconfig
           mountPath: /var/run/secrets/fournos-kubeconfig
@@ -55,20 +49,24 @@ spec:
 
         exec &> >(tee -a "$ARTIFACT_DIR/run.log")
 
-        cat > $ARTIFACT_DIR/forge_config.yaml <<< "$FORGE_CONFIG"
+        oc get "fjob/$FOURNOS_NAME" -n "$FOURNOS_NAMESPACE" -oyaml > $ARTIFACT_DIR/fournos_fjob.yaml
 
-        cat > $ARTIFACT_DIR/forge_config.env <<< "$FOURNOS_ENV"
-
-        if grep -q '^PULL_BASE_SHA=' $ARTIFACT_DIR/forge_config.env; then
-          export PULL_BASE_SHA=$(cat $ARTIFACT_DIR/forge_config.env | grep '^PULL_BASE_SHA=' | cut -d'=' -f2)
+        PULL_BASE_SHA=$(cat "$ARTIFACT_DIR/fournos_fjob.yaml" | yq -r .spec.env.PULL_BASE_SHA)
+        if [[ "$PULL_BASE_SHA" != null ]]; then
+          export PULL_BASE_SHA
+        else
+          unset PULL_BASE_SHA
         fi
 
-        if grep -q '^PULL_PULL_SHA=' $ARTIFACT_DIR/forge_config.env; then
-          export PULL_PULL_SHA=$(cat $ARTIFACT_DIR/forge_config.env | grep '^PULL_PULL_SHA=' | cut -d'=' -f2)
+        PULL_PULL_SHA=$(cat "$ARTIFACT_DIR/fournos_fjob.yaml" | yq -r .spec.env.PULL_PULL_SHA)
+        if [[ "$PULL_PULL_SHA" != null ]]; then
+          export PULL_PULL_SHA
+        else
+          unset PULL_PULL_SHA
         fi
 
         if [[ "${PULL_PULL_SHA:-}" ]]; then
-        echo
+          echo
           echo "Updating to PULL_PULL_SHA=$PULL_PULL_SHA ..."
 
           git -C "$FORGE_HOME" fetch --quiet origin "$PULL_PULL_SHA"
@@ -76,12 +74,15 @@ spec:
         else
           echo "No PULL_PULL_SHA, using the image commit"
         fi
-
         git show --quiet
 
-        export FOURNOS_CI=true
+        FORGE_PROJECT=$(cat "$ARTIFACT_DIR/fournos_fjob.yaml" | yq -r .spec.forge.project)
+        if [[ -z "$FORGE_PROJECT" || "$FORGE_PROJECT" == null ]]; then
+          echo "ERROR: invalid .spec.forge.project='$FORGE_PROJECT' in $FOURNOS_NAMESPACE/$FOURNOS_NAME"
+          exit 1
+        fi
 
-        exec bin/run_ci "$(params.forge-project)" ci "$FOURNOS_STEP"
+        exec bin/run_ci "$FORGE_PROJECT" ci "$FOURNOS_STEP"
 
   volumes:
     - name: kubeconfig

--- a/config/forge/workflows/tasks.yaml
+++ b/config/forge/workflows/tasks.yaml
@@ -17,6 +17,8 @@ spec:
       image: image-registry.openshift-image-registry.svc:5000/$(context.taskRun.namespace)/forge-core:main
       imagePullPolicy: Always
       env:
+      - name: TARGET_KUBECONFIG
+        value: /var/run/secrets/fournos-kubeconfig/kubeconfig
       - name: FJOB_NAME
         value: "$(params.fjob-name)"
       - name: FOURNOS_NAMESPACE
@@ -51,7 +53,7 @@ spec:
         # switching KUBECONFIG to the target cluster.
         oc get "fjob/$FJOB_NAME" -n "$FOURNOS_NAMESPACE" -oyaml > $ARTIFACT_DIR/fournos_fjob.yaml
 
-        export KUBECONFIG=/var/run/secrets/fournos-kubeconfig/kubeconfig
+        export KUBECONFIG=$TARGET_KUBECONFIG
 
         PULL_BASE_SHA=$(cat "$ARTIFACT_DIR/fournos_fjob.yaml" | yq -r .spec.env.PULL_BASE_SHA)
         if [[ "$PULL_BASE_SHA" != null ]]; then

--- a/config/forge/workflows/tasks.yaml
+++ b/config/forge/workflows/tasks.yaml
@@ -17,8 +17,6 @@ spec:
       image: image-registry.openshift-image-registry.svc:5000/$(context.taskRun.namespace)/forge-core:main
       imagePullPolicy: Always
       env:
-      - name: KUBECONFIG
-        value: /var/run/secrets/fournos-kubeconfig/kubeconfig
       - name: FJOB_NAME
         value: "$(params.fjob-name)"
       - name: FOURNOS_NAMESPACE
@@ -49,7 +47,11 @@ spec:
 
         exec &> >(tee -a "$ARTIFACT_DIR/run.log")
 
+        # Fetch FournosJob from the hub cluster (in-cluster SA) before
+        # switching KUBECONFIG to the target cluster.
         oc get "fjob/$FJOB_NAME" -n "$FOURNOS_NAMESPACE" -oyaml > $ARTIFACT_DIR/fournos_fjob.yaml
+
+        export KUBECONFIG=/var/run/secrets/fournos-kubeconfig/kubeconfig
 
         PULL_BASE_SHA=$(cat "$ARTIFACT_DIR/fournos_fjob.yaml" | yq -r .spec.env.PULL_BASE_SHA)
         if [[ "$PULL_BASE_SHA" != null ]]; then

--- a/config/forge/workflows/tasks.yaml
+++ b/config/forge/workflows/tasks.yaml
@@ -49,7 +49,7 @@ spec:
 
         exec &> >(tee -a "$ARTIFACT_DIR/run.log")
 
-        oc get "fjob/$FOURNOS_NAME" -n "$FOURNOS_NAMESPACE" -oyaml > $ARTIFACT_DIR/fournos_fjob.yaml
+        oc get "fjob/$FJOB_NAME" -n "$FOURNOS_NAMESPACE" -oyaml > $ARTIFACT_DIR/fournos_fjob.yaml
 
         PULL_BASE_SHA=$(cat "$ARTIFACT_DIR/fournos_fjob.yaml" | yq -r .spec.env.PULL_BASE_SHA)
         if [[ "$PULL_BASE_SHA" != null ]]; then
@@ -78,7 +78,7 @@ spec:
 
         FORGE_PROJECT=$(cat "$ARTIFACT_DIR/fournos_fjob.yaml" | yq -r .spec.forge.project)
         if [[ -z "$FORGE_PROJECT" || "$FORGE_PROJECT" == null ]]; then
-          echo "ERROR: invalid .spec.forge.project='$FORGE_PROJECT' in $FOURNOS_NAMESPACE/$FOURNOS_NAME"
+          echo "ERROR: invalid .spec.forge.project='$FORGE_PROJECT' in $FOURNOS_NAMESPACE/$FJOB_NAME"
           exit 1
         fi
 

--- a/config/fournos-validation/workflows/pipeline-validate-only.yaml
+++ b/config/fournos-validation/workflows/pipeline-validate-only.yaml
@@ -5,23 +5,12 @@ metadata:
   name: fournos-validate-only
 spec:
   params:
-    - name: job-name
+    - name: fjob-name
       type: string
-    - name: forge-project
+    - name: fournos-namespace
       type: string
-    - name: forge-config
-      type: string
-      default: ""
-    - name: env
-      type: string
-      default: ""
     - name: kubeconfig-secret
       type: string
-    - name: gpu-count
-      type: string
-    - name: secret-refs
-      type: array
-      default: []
   tasks:
     - name: validate
       taskRef:
@@ -29,8 +18,3 @@ spec:
       params:
         - name: kubeconfig-secret
           value: "$(params.kubeconfig-secret)"
-        - name: job-name
-          value: "$(params.job-name)"
-        - name: secret-refs
-          value:
-            - $(params.secret-refs[*])

--- a/config/fournos-validation/workflows/tasks.yaml
+++ b/config/fournos-validation/workflows/tasks.yaml
@@ -6,11 +6,6 @@ spec:
   params:
     - name: kubeconfig-secret
       type: string
-    - name: job-name
-      type: string
-    - name: secret-refs
-      type: array
-      default: []
   steps:
     - name: check-connectivity
       image: bitnami/kubectl:latest

--- a/dev/mock-pipelines/pipeline-full.yaml
+++ b/dev/mock-pipelines/pipeline-full.yaml
@@ -5,22 +5,12 @@ metadata:
   name: fournos-full
 spec:
   params:
-    - name: job-name
+    - name: fjob-name
       type: string
-    - name: forge-project
+    - name: fournos-namespace
       type: string
-    - name: forge-config
-      type: string
-    - name: env
-      type: string
-      default: ""
     - name: kubeconfig-secret
       type: string
-    - name: gpu-count
-      type: string
-    - name: secret-refs
-      type: array
-      default: []
   tasks:
     - name: prepare
       taskRef:
@@ -28,28 +18,17 @@ spec:
       params:
         - name: kubeconfig-secret
           value: "$(params.kubeconfig-secret)"
-        - name: job-name
-          value: "$(params.job-name)"
     - name: run
       runAfter: [prepare]
       taskRef:
         name: fournos-run
       params:
-        - name: forge-project
-          value: "$(params.forge-project)"
-        - name: forge-config
-          value: "$(params.forge-config)"
-        - name: env
-          value: "$(params.env)"
+        - name: fjob-name
+          value: "$(params.fjob-name)"
+        - name: fournos-namespace
+          value: "$(params.fournos-namespace)"
         - name: kubeconfig-secret
           value: "$(params.kubeconfig-secret)"
-        - name: gpu-count
-          value: "$(params.gpu-count)"
-        - name: job-name
-          value: "$(params.job-name)"
-        - name: secret-refs
-          value:
-            - $(params.secret-refs[*])
   finally:
     - name: cleanup
       taskRef:
@@ -57,5 +36,3 @@ spec:
       params:
         - name: kubeconfig-secret
           value: "$(params.kubeconfig-secret)"
-        - name: job-name
-          value: "$(params.job-name)"

--- a/dev/mock-pipelines/pipeline-run-only.yaml
+++ b/dev/mock-pipelines/pipeline-run-only.yaml
@@ -6,39 +6,20 @@ metadata:
   name: fournos-run-only
 spec:
   params:
-    - name: job-name
+    - name: fjob-name
       type: string
-    - name: forge-project
+    - name: fournos-namespace
       type: string
-    - name: forge-config
-      type: string
-    - name: env
-      type: string
-      default: ""
     - name: kubeconfig-secret
       type: string
-    - name: gpu-count
-      type: string
-    - name: secret-refs
-      type: array
-      default: []
   tasks:
     - name: run
       taskRef:
         name: fournos-run
       params:
-        - name: forge-project
-          value: "$(params.forge-project)"
-        - name: forge-config
-          value: "$(params.forge-config)"
-        - name: env
-          value: "$(params.env)"
+        - name: fjob-name
+          value: "$(params.fjob-name)"
+        - name: fournos-namespace
+          value: "$(params.fournos-namespace)"
         - name: kubeconfig-secret
           value: "$(params.kubeconfig-secret)"
-        - name: gpu-count
-          value: "$(params.gpu-count)"
-        - name: job-name
-          value: "$(params.job-name)"
-        - name: secret-refs
-          value:
-            - $(params.secret-refs[*])

--- a/dev/mock-pipelines/tasks.yaml
+++ b/dev/mock-pipelines/tasks.yaml
@@ -9,14 +9,11 @@ spec:
   params:
     - name: kubeconfig-secret
       type: string
-    - name: job-name
-      type: string
   steps:
     - name: validate
       image: busybox:1.36
       script: |
         #!/bin/sh
-        echo "[mock-prepare] job=$(params.job-name)"
         echo "[mock-prepare] kubeconfig-secret=$(params.kubeconfig-secret)"
         echo "[mock-prepare] connectivity check: OK"
 
@@ -27,20 +24,12 @@ metadata:
   name: fournos-run
 spec:
   params:
-    - name: forge-project
+    - name: fjob-name
       type: string
-    - name: forge-config
-      type: string
-    - name: env
+    - name: fournos-namespace
       type: string
     - name: kubeconfig-secret
       type: string
-    - name: gpu-count
-      type: string
-    - name: job-name
-      type: string
-    - name: secret-refs
-      type: array
   steps:
     - name: run-forge
       image: busybox:1.36
@@ -58,13 +47,8 @@ spec:
       script: |
         #!/bin/sh
         MOCK_SLEEP="${MOCK_SLEEP:-3}"
-        echo "[mock-run] forge-project=$(params.forge-project)"
-        echo "[mock-run] forge-config:"
-        echo "$(params.forge-config)" | sed 's/^/  /'
-        echo "[mock-run] env:"
-        echo "$(params.env)" | sed 's/^/  /'
-        echo "[mock-run] gpu-count=$(params.gpu-count)"
-        echo "[mock-run] job=$(params.job-name)"
+        echo "[mock-run] fjob-name=$(params.fjob-name)"
+        echo "[mock-run] fournos-namespace=$(params.fournos-namespace)"
         echo "[mock-run] vault-secrets:"
         find /var/run/secrets/fournos -type f 2>/dev/null | sort | while read f; do echo "  $f ($(wc -c < "$f") bytes)"; done
         echo "[mock-run] simulating workload (${MOCK_SLEEP}s)..."
@@ -80,14 +64,11 @@ spec:
   params:
     - name: kubeconfig-secret
       type: string
-    - name: job-name
-      type: string
   steps:
     - name: cleanup
       image: busybox:1.36
       script: |
         #!/bin/sh
-        echo "[mock-cleanup] job=$(params.job-name)"
         echo "[mock-cleanup] nothing to clean up in mock mode"
 
 ---
@@ -98,41 +79,23 @@ metadata:
   name: fournos-run-only
 spec:
   params:
-    - name: job-name
+    - name: fjob-name
       type: string
-    - name: forge-project
+    - name: fournos-namespace
       type: string
-    - name: forge-config
-      type: string
-    - name: env
-      type: string
-      default: ""
     - name: kubeconfig-secret
       type: string
-    - name: gpu-count
-      type: string
-    - name: secret-refs
-      type: array
-      default: []
   tasks:
     - name: run
       taskRef:
         name: fournos-run
       params:
-        - name: forge-project
-          value: "$(params.forge-project)"
-        - name: forge-config
-          value: "$(params.forge-config)"
-        - name: env
-          value: "$(params.env)"
+        - name: fjob-name
+          value: "$(params.fjob-name)"
+        - name: fournos-namespace
+          value: "$(params.fournos-namespace)"
         - name: kubeconfig-secret
           value: "$(params.kubeconfig-secret)"
-        - name: gpu-count
-          value: "$(params.gpu-count)"
-        - name: job-name
-          value: "$(params.job-name)"
-        - name: secret-refs
-          value: ["$(params.secret-refs[*])"]
 
 ---
 # Mock config — controls mock task behavior.
@@ -143,4 +106,3 @@ metadata:
   name: fournos-mock-config
 data:
   sleep: "3"
-

--- a/dev/mock-resolve/resolve.sh
+++ b/dev/mock-resolve/resolve.sh
@@ -7,21 +7,20 @@
 # always sets secretRefs.
 #
 # Expected env vars (set by the operator):
-#   FOURNOS_JOB_NAME    — FournosJob name to patch
+#   FJOB_NAME    — FournosJob name to patch
 #   FOURNOS_NAMESPACE   — target namespace
-#   FORGE_PROJECT       — Forge project name
 set -euo pipefail
 
-echo "[mock-resolve] job=${FOURNOS_JOB_NAME}"
-echo "[mock-resolve] project=${FORGE_PROJECT}"
+echo "[mock-resolve] job=${FJOB_NAME}"
+echo "[mock-resolve] namespace=${FOURNOS_NAMESPACE}"
 
-EXISTING_HW=$(kubectl get fournosjob "${FOURNOS_JOB_NAME}" \
+EXISTING_HW=$(kubectl get fournosjob "${FJOB_NAME}" \
   -n "${FOURNOS_NAMESPACE}" \
   -o jsonpath='{.spec.hardware.gpuType}' 2>/dev/null || true)
 
 if [[ -z "${EXISTING_HW}" ]]; then
   echo "[mock-resolve] no user-provided hardware, setting defaults"
-  kubectl patch fournosjob "${FOURNOS_JOB_NAME}" \
+  kubectl patch fournosjob "${FJOB_NAME}" \
     -n "${FOURNOS_NAMESPACE}" \
     --type=merge \
     -p '{"spec":{"hardware":{"gpuType":"a100","gpuCount":2}}}'
@@ -30,7 +29,7 @@ else
 fi
 
 echo "[mock-resolve] setting secretRefs"
-kubectl patch fournosjob "${FOURNOS_JOB_NAME}" \
+kubectl patch fournosjob "${FJOB_NAME}" \
   -n "${FOURNOS_NAMESPACE}" \
   --type=merge \
   -p '{"spec":{"secretRefs":["placeholder"]}}'

--- a/dev/mock-resolve/resolve_job.yaml
+++ b/dev/mock-resolve/resolve_job.yaml
@@ -16,8 +16,5 @@ spec:
         - name: resolve
           imagePullPolicy: IfNotPresent
           env:
-            - name: FOURNOS_JOB_NAME
+            - name: FJOB_NAME
             - name: FOURNOS_NAMESPACE
-            - name: FORGE_PROJECT
-            - name: FORGE_CONFIG
-            - name: FOURNOS_ENV

--- a/fournos/core/resolve.py
+++ b/fournos/core/resolve.py
@@ -10,7 +10,6 @@ import yaml
 from kubernetes import client
 
 from fournos.core.constants import LABEL_JOB_NAME, LABEL_MANAGED_BY
-from fournos.core.tekton import serialize_env
 from fournos.settings import settings
 
 logger = logging.getLogger(__name__)
@@ -49,9 +48,6 @@ class ResolveClient:
         self,
         *,
         name: str,
-        forge_project: str,
-        forge_config: dict,
-        env: dict,
         owner_ref: dict,
     ) -> dict:
         job_name = _resolve_job_name(name)
@@ -73,11 +69,8 @@ class ResolveClient:
         )
 
         env_values = {
-            "FOURNOS_JOB_NAME": name,
+            "FJOB_NAME": name,
             "FOURNOS_NAMESPACE": settings.namespace,
-            "FORGE_PROJECT": forge_project,
-            "FORGE_CONFIG": yaml.dump(forge_config, default_flow_style=False),
-            "FOURNOS_ENV": serialize_env(env),
         }
         for env_var in container["env"]:
             if env_var["name"] not in env_values:

--- a/fournos/core/tekton.py
+++ b/fournos/core/tekton.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
 import logging
-import re
-import shlex
-
-import yaml
 
 from kubernetes import client
 
@@ -17,23 +13,6 @@ logger = logging.getLogger(__name__)
 TEKTON_GROUP = "tekton.dev"
 TEKTON_VERSION = "v1"
 TEKTON_PIPELINE_RUN_PLURAL = "pipelineruns"
-
-_ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-
-
-def serialize_env(env: dict) -> str:
-    """Serialize env dict as ``KEY=quoted_value`` lines for ``source``.
-
-    Keys are validated as shell identifiers so they cannot inject
-    shell syntax.  Values are wrapped with :func:`shlex.quote` so
-    ``source`` treats them as literals (no expansion or substitution).
-    """
-    lines: list[str] = []
-    for key, value in env.items():
-        if not _ENV_KEY_RE.match(key):
-            raise ValueError(f"Invalid environment variable name: {key!r}")
-        lines.append(f"{key}={shlex.quote(str(value))}\n")
-    return "".join(lines)
 
 
 def _build_secrets_volume(resolved: list[ResolvedSecret]) -> dict:
@@ -69,13 +48,8 @@ class TektonClient:
         self,
         *,
         name: str,
-        display_name: str,
         pipeline: str,
-        forge_project: str,
-        forge_config: dict,
-        env: dict,
         kubeconfig_secret: str,
-        gpu_count: int,
         resolved_secrets: list[ResolvedSecret],
         cluster: str,
         owner_ref: dict | None = None,
@@ -95,8 +69,6 @@ class TektonClient:
         if owner_ref:
             metadata["ownerReferences"] = [owner_ref]
 
-        secret_ref_names = [r.original_name for r in resolved_secrets]
-
         body = {
             "apiVersion": f"{TEKTON_GROUP}/{TEKTON_VERSION}",
             "kind": "PipelineRun",
@@ -112,19 +84,9 @@ class TektonClient:
                     },
                 },
                 "params": [
-                    {"name": "job-name", "value": display_name},
-                    {"name": "forge-project", "value": forge_project},
-                    {
-                        "name": "forge-config",
-                        "value": yaml.dump(forge_config, default_flow_style=False),
-                    },
-                    {
-                        "name": "env",
-                        "value": serialize_env(env),
-                    },
+                    {"name": "fjob-name", "value": name},
+                    {"name": "fournos-namespace", "value": settings.namespace},
                     {"name": "kubeconfig-secret", "value": kubeconfig_secret},
-                    {"name": "gpu-count", "value": str(gpu_count)},
-                    {"name": "secret-refs", "value": secret_ref_names},
                 ],
             },
         }

--- a/fournos/handlers/execution.py
+++ b/fournos/handlers/execution.py
@@ -167,9 +167,6 @@ def reconcile_admitted(spec, name, namespace, status, patch, body):
             logger.error("Job %s: kubeconfig copy failed: %s", name, exc)
             return
 
-        hardware = spec.get("hardware") or {}
-        gpu_count = hardware.get("gpuCount", 0)
-
         secret_refs_raw = spec.get("secretRefs") or []
         try:
             resolved_secrets = ctx.registry.copy_secrets(
@@ -191,18 +188,11 @@ def reconcile_admitted(spec, name, namespace, status, patch, body):
             logger.error("Job %s: %s", name, exc)
             return
 
-        display_name = spec.get("displayName") or name
-
         try:
             ctx.tekton.create_pipeline_run(
                 name=name,
-                display_name=display_name,
                 pipeline=spec.get("pipeline", "fournos-full"),
-                forge_project=spec["forge"]["project"],
-                forge_config=spec["forge"],
-                env=spec.get("env", {}),
                 kubeconfig_secret=kubeconfig_secret,
-                gpu_count=gpu_count,
                 resolved_secrets=resolved_secrets,
                 cluster=cluster,
                 owner_ref=owner_ref(body),

--- a/fournos/handlers/resolving.py
+++ b/fournos/handlers/resolving.py
@@ -60,9 +60,6 @@ def _ensure_resolve_job(spec, name, conditions, patch, body):
     try:
         ctx.resolve.create_job(
             name=name,
-            forge_project=spec["forge"]["project"],
-            forge_config=spec["forge"],
-            env=spec.get("env", {}),
             owner_ref=owner_ref(body),
         )
     except client.exceptions.ApiException as exc:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import subprocess
-import textwrap
 import time
 from typing import Any
 
@@ -452,20 +451,9 @@ def create_stale_pipelinerun(k8s, name: str) -> None:
         "spec": {
             "pipelineRef": {"name": "fournos-run-only"},
             "params": [
-                {"name": "job-name", "value": name},
-                {"name": "forge-project", "value": "test/stale"},
-                {
-                    "name": "forge-config",
-                    "value": textwrap.dedent("""\
-                        project: test/stale
-                        args:
-                        - cks
-                        - internal-test
-                    """),
-                },
-                {"name": "env", "value": ""},
+                {"name": "fjob-name", "value": name},
+                {"name": "fournos-namespace", "value": NAMESPACE},
                 {"name": "kubeconfig-secret", "value": f"{name}-kubeconfig"},
-                {"name": "gpu-count", "value": "0"},
             ],
         },
     }

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -1,7 +1,5 @@
 """Scheduling tests — cluster pinning, hardware requests, Kueue admission."""
 
-import yaml
-
 from fournos.core.constants import MAX_CLUSTER_SLOTS, Phase
 from tests.conftest import (
     NAMESPACE,
@@ -61,11 +59,6 @@ def test_cluster_pinned(k8s):
     ), f"Copied kubeconfig should have FournosJob ownerRef, got {kc_owners!r}"
     assert kc.get("metadata", {}).get("namespace") == NAMESPACE, (
         "Copied kubeconfig should be in the operator namespace"
-    )
-
-    refs = get_pipelinerun_param("test-cluster", "secret-refs")
-    assert refs == ["placeholder"], (
-        f"Mock resolver should set secret-refs to ['placeholder'], got {refs!r}"
     )
 
     phase = poll_phase(
@@ -307,64 +300,3 @@ def test_cluster_without_required_gpu_stays_pending(k8s):
     assert phase == Phase.PENDING, (
         f"Job requesting A100s on cluster-3 should stay Pending, got {phase!r}"
     )
-
-
-def test_optional_spec_fields(k8s):
-    """displayName, owner, args, configOverrides, and env are all forwarded correctly."""
-    overrides = {
-        "config": {
-            "batch_size": 64,
-            "vllm": {"version": "0.15.1"},
-        },
-        "logging": {"enabled": True, "level": "debug"},
-        "tags": ["special", "demo"],
-    }
-    env = {"OCPCI_SUITE": "regression", "OCPCI_VARIANT": "nightly"}
-
-    create_job(
-        k8s,
-        "test-opts",
-        {
-            "owner": "perf-team",
-            "displayName": "nightly-llama3-benchmark",
-            "cluster": "cluster-1",
-            "forge": {
-                "project": "testproj/llmd",
-                "args": ["cks", "internal-test"],
-                "configOverrides": overrides,
-            },
-            "env": env,
-        },
-    )
-
-    job = get_job(k8s, "test-opts")
-    assert job["spec"]["owner"] == "perf-team", (
-        f"Owner should be perf-team, got {job['spec'].get('owner')!r}"
-    )
-
-    poll_phase(
-        k8s,
-        "test-opts",
-        terminal={Phase.RUNNING, Phase.SUCCEEDED, Phase.FAILED},
-        timeout=30,
-    )
-
-    job_name_param = get_pipelinerun_param("test-opts", "job-name")
-    assert job_name_param == "nightly-llama3-benchmark", (
-        f"PipelineRun job-name param should be the displayName, got {job_name_param!r}"
-    )
-
-    forge_param = yaml.safe_load(get_pipelinerun_param("test-opts", "forge-config"))
-    assert forge_param["project"] == "testproj/llmd", (
-        f"forge.project mismatch: {forge_param.get('project')!r}"
-    )
-    assert forge_param["args"] == ["cks", "internal-test"], (
-        f"forge.args mismatch: {forge_param.get('args')!r}"
-    )
-    assert forge_param.get("configOverrides") == overrides, (
-        f"forge.configOverrides mismatch: {forge_param.get('configOverrides')}"
-    )
-
-    env_raw = get_pipelinerun_param("test-opts", "env")
-    env_param = dict(line.split("=", 1) for line in env_raw.strip().splitlines())
-    assert env_param == env, f"env param mismatch: {env_param}"

--- a/tests/test_secret_refs.py
+++ b/tests/test_secret_refs.py
@@ -25,7 +25,6 @@ from tests.conftest import (
     SECRETS_NAMESPACE,
     create_job,
     create_noop_resolve_job,
-    get_pipelinerun_param,
     get_pipelinerun_volumes,
     job_status_summary,
     poll_phase,
@@ -128,11 +127,6 @@ def test_vault_sync_then_fjob(k8s, core_v1):
         )
         assert phase in ("Running", "Succeeded"), job_status_summary(
             k8s, "test-e2e-secret"
-        )
-
-        refs_param = get_pipelinerun_param("test-e2e-secret", "secret-refs")
-        assert refs_param == [VAULT_ENTRY], (
-            f"PipelineRun secret-refs should be {[VAULT_ENTRY]!r}, got {refs_param!r}"
         )
 
         volumes = get_pipelinerun_volumes("test-e2e-secret")


### PR DESCRIPTION
Instead of extracting `forge-project`, `forge-config`, and `env` from the `FournosJob` spec and passing them as separate PipelineRun/resolve Job params, Fournos now passes only `FJOB_NAME` and `FOURNOS_NAMESPACE`. FORGE looks up the full `FournosJob` spec via the K8s API, giving it access to all configuration in one go.

This also drops `job-name`, `gpu-count`, and `secret-refs` as pipeline params since FORGE can read those from the spec directly if required. The only params remaining on the PipelineRun are `fjob-name`, `fournos-namespace`, and `kubeconfig-secret`.

Closes https://github.com/openshift-psap/fournos/issues/61

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Operator now supplies only job name and namespace; pipelines and runtime components resolve full job specs from Kubernetes, simplifying parameter contracts across workflows.
* **Documentation**
  * Design doc and README updated to describe the new lookup-based configuration flow.
* **Tests**
  * Test suites and helpers adjusted to reflect the narrowed pipeline parameter surface and removed legacy parameter assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->