### PR TITLE
Support artifacts export via Tekton volumeClaimTemplate

### DIFF
--- a/Fournos_Design_Document.md
+++ b/Fournos_Design_Document.md
@@ -286,12 +286,14 @@ FORGE-owned tasks (stubs in this repo, replaced by real FORGE implementation):
 ### Pipelines
 
 
-| Pipeline           | File                                                              | Tasks         | Finally  |
-| ------------------ | ----------------------------------------------------------------- | ------------- | -------- |
-| `fournos-full`     | [pipeline-full.yaml](config/forge/workflows/pipeline-full.yaml)         | prepare → run | cleanup  |
-| `fournos-run-only` | [pipeline-run-only.yaml](dev/mock-pipelines/pipeline-run-only.yaml) *(kind / tests)* | run           | *(none)* |
+| Pipeline           | File                                                              | Tasks                          | Finally                        |
+| ------------------ | ----------------------------------------------------------------- | ------------------------------ | ------------------------------ |
+| `forge-full`       | [pipeline-full.yaml](config/forge/workflows/pipeline-full.yaml)         | pre-cleanup, prepare → test    | export-artifacts, post-cleanup |
+| `forge-test-only`  | [pipeline-test-only.yaml](config/forge/workflows/pipeline-test-only.yaml) | test                           | export-artifacts               |
+| `fournos-full`     | [pipeline-full.yaml](dev/mock-pipelines/pipeline-full.yaml) *(kind / tests)* | prepare → run                  | cleanup                        |
+| `fournos-run-only` | [pipeline-run-only.yaml](dev/mock-pipelines/pipeline-run-only.yaml) *(kind / tests)* | run                            | *(none)*                       |
 
-For a run-only pipeline in real hub deployments, use [pipeline-test-only.yaml](config/forge/workflows/pipeline-test-only.yaml) (`forge-test-only`).
+All pipelines declare an `artifacts` workspace backed by a `volumeClaimTemplate` PVC (auto-provisioned per PipelineRun). Each task writes to a step-specific subdirectory under the shared mount, and the `export-artifacts` finally task has access to the full artifact tree.
 
 The `spec.pipeline` field in `FournosJob` selects which pipeline to use (default: `fournos-full`).
 

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ All settings are read from environment variables with the `FOURNOS_` prefix:
 | `FOURNOS_RESOLVE_IMAGE` | `image-registry.openshift-image-registry.svc:5000/{namespace}/forge-core:main` | Container image for the resolve Job (`{namespace}` is substituted at runtime) |
 | `FOURNOS_RESOLVE_DEADLINE_SEC` | `300` | Deadline for the resolve Job (seconds) |
 | `FOURNOS_RESOLVE_JOB_TEMPLATE` | `config/forge/resolve_job.yaml` | Path (relative to project root) to the Job YAML template for the resolve step. Override with `dev/mock-resolve/resolve_job.yaml` for local dev/CI. |
+| `FOURNOS_ARTIFACT_PVC_SIZE` | `1Gi` | Size of the per-PipelineRun PVC used for shared artifact storage across pipeline tasks |
 
 ## Architecture
 
@@ -324,7 +325,7 @@ The operator runs as a single-replica Deployment using
 1. **Resolves** job requirements by launching a Forge K8s Job that populates the FournosJob spec with GPU type/count and secret references
 2. **Creates** a Kueue Workload with the resolved GPU resources (owned by the FournosJob via `ownerReferences`)
 3. **Polls** (5 s timer) for Kueue admission and assigned cluster
-4. **Copies** referenced Vault secrets from the secrets namespace into the operator namespace (per-job copies with `ownerReferences` for automatic cleanup) and **launches** a Tekton PipelineRun with `FJOB_NAME` + `FOURNOS_NAMESPACE` (so FORGE can look up the full FournosJob spec) and the secrets mounted as a projected volume at `/var/run/secrets/fournos/` (owned by the FournosJob via `ownerReferences`)
+4. **Copies** referenced Vault secrets from the secrets namespace into the operator namespace (per-job copies with `ownerReferences` for automatic cleanup) and **launches** a Tekton PipelineRun with `FJOB_NAME` + `FOURNOS_NAMESPACE` (so FORGE can look up the full FournosJob spec), the secrets mounted as a projected volume at `/var/run/secrets/fournos/` (owned by the FournosJob via `ownerReferences`), and a shared `artifacts` workspace backed by a `volumeClaimTemplate` PVC for cross-task artifact storage (managed by Tekton)
 5. **Watches** the PipelineRun until completion
 6. **Deletes** the Workload to release Kueue quota
 

--- a/config/forge/workflows/pipeline-full.yaml
+++ b/config/forge/workflows/pipeline-full.yaml
@@ -1,9 +1,11 @@
-# Full three-step pipeline: pre_cleanup -> prepare → test → post-cleanup.
+# Full pipeline: pre_cleanup -> prepare → test → export-artifacts + post-cleanup.
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: forge-full
 spec:
+  workspaces:
+    - name: artifacts
   params:
     - name: fjob-name
       type: string
@@ -16,6 +18,9 @@ spec:
     - name: pre-cleanup
       taskRef:
         name: forge-step
+      workspaces:
+        - name: artifacts
+          workspace: artifacts
       params:
         - name: fjob-name
           value: "$(params.fjob-name)"
@@ -29,6 +34,9 @@ spec:
     - name: prepare
       taskRef:
         name: forge-step
+      workspaces:
+        - name: artifacts
+          workspace: artifacts
       params:
         - name: fjob-name
           value: "$(params.fjob-name)"
@@ -43,6 +51,9 @@ spec:
       runAfter: [prepare]
       taskRef:
         name: forge-step
+      workspaces:
+        - name: artifacts
+          workspace: artifacts
       params:
         - name: fjob-name
           value: "$(params.fjob-name)"
@@ -54,9 +65,28 @@ spec:
           value: test
 
   finally:
+    - name: export-artifacts
+      taskRef:
+        name: forge-step
+      workspaces:
+        - name: artifacts
+          workspace: artifacts
+      params:
+        - name: fjob-name
+          value: "$(params.fjob-name)"
+        - name: fournos-namespace
+          value: "$(params.fournos-namespace)"
+        - name: kubeconfig-secret
+          value: "$(params.kubeconfig-secret)"
+        - name: job-step
+          value: export-artifacts
+
     - name: post-cleanup
       taskRef:
         name: forge-step
+      workspaces:
+        - name: artifacts
+          workspace: artifacts
       params:
         - name: fjob-name
           value: "$(params.fjob-name)"

--- a/config/forge/workflows/pipeline-full.yaml
+++ b/config/forge/workflows/pipeline-full.yaml
@@ -30,6 +30,8 @@ spec:
           value: "$(params.kubeconfig-secret)"
         - name: job-step
           value: pre-cleanup
+        - name: job-step-name
+          value: 000__pre-cleanup
 
     - name: prepare
       taskRef:
@@ -46,6 +48,8 @@ spec:
           value: "$(params.kubeconfig-secret)"
         - name: job-step
           value: prepare
+        - name: job-step-name
+          value: 001__prepare
 
     - name: test
       runAfter: [prepare]
@@ -63,6 +67,8 @@ spec:
           value: "$(params.kubeconfig-secret)"
         - name: job-step
           value: test
+        - name: job-step-name
+          value: 002__test
 
   finally:
     - name: export-artifacts
@@ -80,6 +86,8 @@ spec:
           value: "$(params.kubeconfig-secret)"
         - name: job-step
           value: export-artifacts
+        - name: job-step-name
+          value: 003__export-artifacts
 
     - name: post-cleanup
       taskRef:
@@ -96,3 +104,5 @@ spec:
           value: "$(params.kubeconfig-secret)"
         - name: job-step
           value: pre-cleanup # there's currently no post-cleanup step
+        - name: job-step-name
+          value: 004__post-cleanup

--- a/config/forge/workflows/pipeline-test-only.yaml
+++ b/config/forge/workflows/pipeline-test-only.yaml
@@ -29,7 +29,9 @@ spec:
         - name: kubeconfig-secret
           value: "$(params.kubeconfig-secret)"
         - name: job-step
-          value: "test"
+          value: test
+        - name: job-step-name
+          value: 000__test
 
   finally:
     - name: export-artifacts
@@ -47,3 +49,5 @@ spec:
           value: "$(params.kubeconfig-secret)"
         - name: job-step
           value: export-artifacts
+        - name: job-step-name
+          value: 001__export-artifacts

--- a/config/forge/workflows/pipeline-test-only.yaml
+++ b/config/forge/workflows/pipeline-test-only.yaml
@@ -5,6 +5,8 @@ kind: Pipeline
 metadata:
   name: forge-test-only
 spec:
+  workspaces:
+    - name: artifacts
   params:
     - name: fjob-name
       type: string
@@ -16,6 +18,9 @@ spec:
     - name: test
       taskRef:
         name: forge-step
+      workspaces:
+        - name: artifacts
+          workspace: artifacts
       params:
         - name: fjob-name
           value: "$(params.fjob-name)"
@@ -25,3 +30,20 @@ spec:
           value: "$(params.kubeconfig-secret)"
         - name: job-step
           value: "test"
+
+  finally:
+    - name: export-artifacts
+      taskRef:
+        name: forge-step
+      workspaces:
+        - name: artifacts
+          workspace: artifacts
+      params:
+        - name: fjob-name
+          value: "$(params.fjob-name)"
+        - name: fournos-namespace
+          value: "$(params.fournos-namespace)"
+        - name: kubeconfig-secret
+          value: "$(params.kubeconfig-secret)"
+        - name: job-step
+          value: export-artifacts

--- a/config/forge/workflows/tasks.yaml
+++ b/config/forge/workflows/tasks.yaml
@@ -3,6 +3,9 @@ kind: Task
 metadata:
   name: forge-step
 spec:
+  workspaces:
+    - name: artifacts
+      description: Shared artifact storage across pipeline tasks.
   params:
     - name: fjob-name
       type: string
@@ -44,7 +47,8 @@ spec:
         set -o nounset
         set -o errtrace
 
-        export ARTIFACT_DIR=/tmp/artifacts
+        export ARTIFACT_BASE_DIR="$(workspaces.artifacts.path)"
+        export ARTIFACT_DIR="${ARTIFACT_BASE_DIR}/${FOURNOS_STEP}"
         mkdir -p "${ARTIFACT_DIR}"
 
         exec &> >(tee -a "$ARTIFACT_DIR/run.log")

--- a/config/forge/workflows/tasks.yaml
+++ b/config/forge/workflows/tasks.yaml
@@ -15,6 +15,8 @@ spec:
       type: string
     - name: job-step
       type: string
+    - name: job-step-name
+      type: string
   steps:
     - name: forge
       image: image-registry.openshift-image-registry.svc:5000/$(context.taskRun.namespace)/forge-core:main
@@ -28,6 +30,8 @@ spec:
         value: "$(params.fournos-namespace)"
       - name: FOURNOS_STEP
         value: "$(params.job-step)"
+      - name: FOURNOS_STEP_NAME
+        value: "$(params.job-step-name)"
       - name: FOURNOS_SECRETS
         value: /var/run/secrets/fournos
       - name: FOURNOS_CI
@@ -48,7 +52,7 @@ spec:
         set -o errtrace
 
         export ARTIFACT_BASE_DIR="$(workspaces.artifacts.path)"
-        export ARTIFACT_DIR="${ARTIFACT_BASE_DIR}/${FOURNOS_STEP}"
+        export ARTIFACT_DIR="${ARTIFACT_BASE_DIR}/${FOURNOS_STEP_NAME}"
         mkdir -p "${ARTIFACT_DIR}"
 
         exec &> >(tee -a "$ARTIFACT_DIR/run.log")

--- a/dev/mock-pipelines/pipeline-full.yaml
+++ b/dev/mock-pipelines/pipeline-full.yaml
@@ -4,6 +4,8 @@ kind: Pipeline
 metadata:
   name: fournos-full
 spec:
+  workspaces:
+    - name: artifacts
   params:
     - name: fjob-name
       type: string
@@ -15,6 +17,9 @@ spec:
     - name: prepare
       taskRef:
         name: fournos-prepare
+      workspaces:
+        - name: artifacts
+          workspace: artifacts
       params:
         - name: kubeconfig-secret
           value: "$(params.kubeconfig-secret)"
@@ -22,6 +27,9 @@ spec:
       runAfter: [prepare]
       taskRef:
         name: fournos-run
+      workspaces:
+        - name: artifacts
+          workspace: artifacts
       params:
         - name: fjob-name
           value: "$(params.fjob-name)"
@@ -33,6 +41,9 @@ spec:
     - name: cleanup
       taskRef:
         name: fournos-cleanup
+      workspaces:
+        - name: artifacts
+          workspace: artifacts
       params:
         - name: kubeconfig-secret
           value: "$(params.kubeconfig-secret)"

--- a/dev/mock-pipelines/pipeline-run-only.yaml
+++ b/dev/mock-pipelines/pipeline-run-only.yaml
@@ -5,6 +5,8 @@ kind: Pipeline
 metadata:
   name: fournos-run-only
 spec:
+  workspaces:
+    - name: artifacts
   params:
     - name: fjob-name
       type: string
@@ -16,6 +18,9 @@ spec:
     - name: run
       taskRef:
         name: fournos-run
+      workspaces:
+        - name: artifacts
+          workspace: artifacts
       params:
         - name: fjob-name
           value: "$(params.fjob-name)"

--- a/dev/mock-pipelines/tasks.yaml
+++ b/dev/mock-pipelines/tasks.yaml
@@ -6,6 +6,8 @@ kind: Task
 metadata:
   name: fournos-prepare
 spec:
+  workspaces:
+    - name: artifacts
   params:
     - name: kubeconfig-secret
       type: string
@@ -23,6 +25,8 @@ kind: Task
 metadata:
   name: fournos-run
 spec:
+  workspaces:
+    - name: artifacts
   params:
     - name: fjob-name
       type: string
@@ -51,6 +55,10 @@ spec:
         echo "[mock-run] fournos-namespace=$(params.fournos-namespace)"
         echo "[mock-run] vault-secrets:"
         find /var/run/secrets/fournos -type f 2>/dev/null | sort | while read f; do echo "  $f ($(wc -c < "$f") bytes)"; done
+        ARTIFACT_DIR="$(workspaces.artifacts.path)/run"
+        mkdir -p "$ARTIFACT_DIR"
+        echo "mock-run" > "$ARTIFACT_DIR/marker.txt"
+        echo "[mock-run] wrote artifact marker to $ARTIFACT_DIR/marker.txt"
         echo "[mock-run] simulating workload (${MOCK_SLEEP}s)..."
         sleep "$MOCK_SLEEP"
         echo "[mock-run] done"
@@ -61,6 +69,8 @@ kind: Task
 metadata:
   name: fournos-cleanup
 spec:
+  workspaces:
+    - name: artifacts
   params:
     - name: kubeconfig-secret
       type: string
@@ -78,6 +88,8 @@ kind: Pipeline
 metadata:
   name: fournos-run-only
 spec:
+  workspaces:
+    - name: artifacts
   params:
     - name: fjob-name
       type: string
@@ -89,6 +101,9 @@ spec:
     - name: run
       taskRef:
         name: fournos-run
+      workspaces:
+        - name: artifacts
+          workspace: artifacts
       params:
         - name: fjob-name
           value: "$(params.fjob-name)"

--- a/fournos/core/tekton.py
+++ b/fournos/core/tekton.py
@@ -88,6 +88,21 @@ class TektonClient:
                     {"name": "fournos-namespace", "value": settings.namespace},
                     {"name": "kubeconfig-secret", "value": kubeconfig_secret},
                 ],
+                "workspaces": [
+                    {
+                        "name": "artifacts",
+                        "volumeClaimTemplate": {
+                            "spec": {
+                                "accessModes": ["ReadWriteOnce"],
+                                "resources": {
+                                    "requests": {
+                                        "storage": settings.artifact_pvc_size,
+                                    },
+                                },
+                            },
+                        },
+                    },
+                ],
             },
         }
         result = self._k8s.create_namespaced_custom_object(

--- a/fournos/settings.py
+++ b/fournos/settings.py
@@ -22,6 +22,7 @@ class Settings(BaseSettings):
     )
     resolve_deadline_sec: int = Field(default=300, gt=0)
     resolve_job_template: str = "config/forge/resolve_job.yaml"
+    artifact_pvc_size: str = "1Gi"
 
 
 settings = Settings()

--- a/fournos/settings.py
+++ b/fournos/settings.py
@@ -22,7 +22,7 @@ class Settings(BaseSettings):
     )
     resolve_deadline_sec: int = Field(default=300, gt=0)
     resolve_job_template: str = "config/forge/resolve_job.yaml"
-    artifact_pvc_size: str = "5Gi"
+    artifact_pvc_size: str = "10Gi"
 
 
 settings = Settings()

--- a/fournos/settings.py
+++ b/fournos/settings.py
@@ -22,7 +22,7 @@ class Settings(BaseSettings):
     )
     resolve_deadline_sec: int = Field(default=300, gt=0)
     resolve_job_template: str = "config/forge/resolve_job.yaml"
-    artifact_pvc_size: str = "1Gi"
+    artifact_pvc_size: str = "5Gi"
 
 
 settings = Settings()

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -160,6 +160,13 @@ spec:
                   type: string
                 message:
                   type: string
+                engineStatus:
+                  type: object
+                  description: >-
+                    Opaque status blob written by the benchmark execution engine.
+                    Fournos preserves it as-is for callers (e.g. OCPCI) to
+                    read back information such as artifact URLs.
+                  x-kubernetes-preserve-unknown-fields: true
                 conditions:
                   type: array
                   items:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -288,6 +288,12 @@ def get_pipelinerun_volumes(name: str) -> list[dict]:
     )
 
 
+def get_pipelinerun_workspaces(name: str) -> list[dict]:
+    """Return the workspaces from the PipelineRun spec."""
+    pr = get_k8s_resource("pipelinerun", name)
+    return pr.get("spec", {}).get("workspaces", [])
+
+
 def resolve_job_exists(name: str) -> bool:
     """Check whether the resolve Job for *name* exists."""
     result = subprocess.run(

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -7,6 +7,7 @@ from tests.conftest import (
     get_job,
     get_k8s_resource,
     get_pipelinerun_param,
+    get_pipelinerun_workspaces,
     get_workload_cluster_slots,
     get_workload_flavor,
     get_workload_gpu_request,
@@ -46,6 +47,15 @@ def test_cluster_pinned(k8s):
     secret = get_pipelinerun_param("test-cluster", "kubeconfig-secret")
     assert secret == "test-cluster-kubeconfig", (
         f"PipelineRun kubeconfig-secret should be test-cluster-kubeconfig, got {secret!r}"
+    )
+
+    workspaces = get_pipelinerun_workspaces("test-cluster")
+    artifacts_ws = next((w for w in workspaces if w["name"] == "artifacts"), None)
+    assert artifacts_ws is not None, (
+        f"PipelineRun should have an 'artifacts' workspace, got {workspaces!r}"
+    )
+    assert "volumeClaimTemplate" in artifacts_ws, (
+        f"artifacts workspace should use volumeClaimTemplate, got {artifacts_ws!r}"
     )
 
     kc = get_k8s_resource("secret", "test-cluster-kubeconfig")


### PR DESCRIPTION
Implement support for artifacts export from Forge by mounting a Tekton PipelineRun scoped volumeClaimTemplate.
Closes https://github.com/openshift-psap/fournos/issues/15.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced shared artifact storage across pipeline tasks, backed by a dynamically provisioned PersistentVolumeClaim. Configure storage size using the `FOURNOS_ARTIFACT_PVC_SIZE` environment variable (default: `5Gi`).
  * Added automatic artifact export functionality to finalize artifact collection after pipeline execution.

* **Documentation**
  * Updated architecture and setup documentation to describe artifact storage configuration and workspace implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->