### PR TITLE
Add Fournos labels to Tekton managed workspace PVCs; fix RBAC for default Tekton pipeline SA

### DIFF
--- a/fournos/core/tekton.py
+++ b/fournos/core/tekton.py
@@ -92,6 +92,9 @@ class TektonClient:
                     {
                         "name": "artifacts",
                         "volumeClaimTemplate": {
+                            "metadata": {
+                                "labels": labels,
+                            },
                             "spec": {
                                 "accessModes": ["ReadWriteOnce"],
                                 "resources": {

--- a/manifests/ocpci-sa/rbac-wip-ns.yaml
+++ b/manifests/ocpci-sa/rbac-wip-ns.yaml
@@ -22,7 +22,10 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ocpci
-    namespace: psap-automation  # This points back to the original namespace
+    namespace: psap-automation
+  - kind: ServiceAccount
+    name: pipeline
+    namespace: psap-automation-wip
 roleRef:
   kind: Role
   name: ocpci-fournos-job-manager


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Ensured labels are properly propagated to dynamically created storage volumes during pipeline execution.

* **Chores**
  * Updated access control configuration to support additional pipeline service accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->