### PR TITLE
Adjust tags in image-push GHA

### DIFF
--- a/.github/workflows/image-push.yaml
+++ b/.github/workflows/image-push.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Determine tags
         id: tags
         run: |
-          TAGS="${{ github.sha }}"
+          TAGS="$(git rev-parse --short HEAD)"
           if [[ "${{ github.event_name }}" == "push" ]]; then
             TAGS="latest ${TAGS}"
           fi

--- a/.github/workflows/image-push.yaml
+++ b/.github/workflows/image-push.yaml
@@ -1,8 +1,10 @@
 name: Image Push
 on:
-  workflow_dispatch:
   release:
     types: [published]
+  push:
+    branches: [main]
+  workflow_dispatch: {}
 
 jobs:
   image-push:
@@ -10,13 +12,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Determine tags
+        id: tags
+        run: |
+          TAGS="${{ github.sha }}"
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            TAGS="latest ${TAGS}"
+          fi
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            TAGS="stable ${TAGS} ${{ github.event.release.tag_name }}"
+          fi
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+
       - name: Build Fournos Image
         id: build
         uses: redhat-actions/buildah-build@v2
         with:
           image: fournos
           context: .
-          tags: latest ${{ github.sha }}
+          tags: ${{ steps.tags.outputs.tags }}
           containerfiles: |
             ./Containerfile
 


### PR DESCRIPTION
Preparation step for https://github.com/openshift-psap/fournos/issues/8.
Change of image push behavior and tags:
* Build images on main branch merges and push them with `latests` tag.
* Build images on GH release and push them with `stable` and `release` tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated deployment process: container image workflow now automatically triggers on both code pushes to main and official release publications. Image tagging strategy enhanced to apply context-aware labels—`latest` with commit identifiers for development builds, `stable` with version numbers for production releases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openshift-psap/fournos/pull/80)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->