### PR TITLE
feat: add lockOnly support for sentinel cluster-lock jobs

### DIFF
--- a/fournos/handlers/execution.py
+++ b/fournos/handlers/execution.py
@@ -142,6 +142,13 @@ def _finish_stop(name, conditions, patch, pr_message):
 
 
 def reconcile_admitted(spec, name, namespace, status, patch, body):
+    if spec.get("lockOnly", False):
+        cluster = status.get("cluster", spec.get("cluster", ""))
+        new_msg = f"Cluster lock held on {cluster}"
+        if status.get("message") != new_msg:
+            patch.status["message"] = new_msg
+        return
+
     pr = ctx.tekton.get_pipeline_run_or_none(name)
     conditions = list(status.get("conditions") or [])
 

--- a/fournos/handlers/lifecycle.py
+++ b/fournos/handlers/lifecycle.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 
-from kubernetes import client
+from kubernetes import client as k8s_client
 
 from fournos.core.constants import (
     CLUSTER_SLOT_RESOURCE,
@@ -25,6 +25,7 @@ from .status import (
     CRD_GROUP,
     CRD_VERSION,
     COND_WORKLOAD_ADMITTED,
+    owner_ref,
     set_condition,
 )
 
@@ -49,6 +50,17 @@ def on_create(spec, name, namespace, status, patch, body):
 
     cluster = spec.get("cluster")
     exclusive = spec["exclusive"]
+    lock_only = spec.get("lockOnly", False)
+
+    if lock_only and not cluster:
+        patch.status["phase"] = Phase.FAILED
+        patch.status["message"] = "lockOnly: true requires 'cluster' to be set"
+        return
+
+    if not lock_only and not spec.get("executionEngine"):
+        patch.status["phase"] = Phase.FAILED
+        patch.status["message"] = "spec.executionEngine is required for non-lockOnly jobs"
+        return
 
     if exclusive and not cluster:
         patch.status["phase"] = Phase.FAILED
@@ -58,7 +70,7 @@ def on_create(spec, name, namespace, status, patch, body):
     if cluster:
         try:
             known_flavors = ctx.kueue.list_flavors()
-        except client.exceptions.ApiException as exc:
+        except k8s_client.exceptions.ApiException as exc:
             patch.status["phase"] = Phase.FAILED
             patch.status["message"] = f"Failed to list clusters: {exc.reason}"
             logger.error("Job %s: list_flavors failed: %s", name, exc.reason)
@@ -71,9 +83,44 @@ def on_create(spec, name, namespace, status, patch, body):
     if exclusive:
         patch.meta.setdefault("labels", {})[LABEL_EXCLUSIVE_CLUSTER] = cluster
 
+    if lock_only:
+        _create_lock_workload(spec, name, patch, body)
+        return
+
     patch.status["phase"] = Phase.RESOLVING
     patch.status["message"] = "Resolving job requirements"
     logger.info("Job %s: phase=Resolving", name)
+
+
+def _create_lock_workload(spec, name, patch, body):
+    """Create a Kueue Workload that holds cluster-slot quota without running a pipeline."""
+    conditions = []
+    try:
+        ctx.kueue.create_workload(
+            name=name,
+            gpu_type=None,
+            gpu_count=0,
+            cluster=spec["cluster"],
+            exclusive=True,
+            priority=spec.get("priority"),
+            owner_ref=owner_ref(body),
+        )
+    except k8s_client.exceptions.ApiException as exc:
+        if exc.status != 409:
+            raise
+        logger.debug("Job %s: lock Workload already exists (409)", name)
+
+    patch.status["phase"] = Phase.PENDING
+    patch.status["message"] = "Cluster lock pending admission"
+    set_condition(
+        patch,
+        conditions,
+        COND_WORKLOAD_ADMITTED,
+        "False",
+        "Pending",
+        "Lock workload created, waiting for Kueue admission",
+    )
+    logger.info("Job %s: lockOnly=true, created lock Workload, phase=Pending", name)
 
 
 # ---------------------------------------------------------------------------
@@ -88,7 +135,7 @@ def _find_exclusive_locker(cluster: str, exclude_job: str) -> str | None:
     Returns None on API errors so reconciliation is not interrupted.
     """
     try:
-        custom = client.CustomObjectsApi()
+        custom = k8s_client.CustomObjectsApi()
         jobs = custom.list_namespaced_custom_object(
             CRD_GROUP,
             CRD_VERSION,
@@ -96,7 +143,7 @@ def _find_exclusive_locker(cluster: str, exclude_job: str) -> str | None:
             "fournosjobs",
             label_selector=f"{LABEL_EXCLUSIVE_CLUSTER}={cluster}",
         )
-    except client.exceptions.ApiException:
+    except k8s_client.exceptions.ApiException:
         logger.warning("Failed to query exclusive locker for cluster %s", cluster)
         return None
     for job in jobs.get("items", []):

--- a/fournos/handlers/lifecycle.py
+++ b/fournos/handlers/lifecycle.py
@@ -59,7 +59,9 @@ def on_create(spec, name, namespace, status, patch, body):
 
     if not lock_only and not spec.get("executionEngine"):
         patch.status["phase"] = Phase.FAILED
-        patch.status["message"] = "spec.executionEngine is required for non-lockOnly jobs"
+        patch.status["message"] = (
+            "spec.executionEngine is required for non-lockOnly jobs"
+        )
         return
 
     if exclusive and not cluster:

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -50,8 +50,7 @@ spec:
           properties:
             spec:
               type: object
-              required:
-                - executionEngine
+              required: []
               properties:
                 owner:
                   type: string
@@ -116,6 +115,16 @@ spec:
                     Requires 'cluster' to be set.  Hardware is optional — when
                     omitted the Workload only requests cluster-slot resources
                     for locking.
+                lockOnly:
+                  type: boolean
+                  default: false
+                  description: >-
+                    Sentinel lock job that holds cluster quota without running
+                    a pipeline. Created by the hearth controller to
+                    implement human-driven cluster ownership. Implies
+                    exclusive: true and requires 'cluster'. Skips execution
+                    engine resolution and PipelineRun creation — the job
+                    stays Admitted indefinitely until deleted.
                 priority:
                   type: string
                 shutdown:


### PR DESCRIPTION
## Summary

- Adds `lockOnly` boolean field to FournosJob CRD — sentinel jobs that hold cluster-slot quota without running a pipeline
- Adds lockOnly validation and lock workload creation in `lifecycle.py` (skips Forge/execution engine resolution)
- Adds early return in `execution.py::reconcile_admitted()` so lockOnly jobs stay Admitted indefinitely
- Removes `executionEngine` from CRD required fields (lockOnly jobs don't need one)

**Context:** The hearth controller (cluster lifecycle operator) creates sentinel FournosJobs with `lockOnly: true` to implement human-driven cluster locking. Without this change, the execution controller tries to create a PipelineRun for the sentinel and fails with "Failed to fetch Pipeline".

## Test plan

- [ ] Verify existing integration tests still pass
- [ ] Lock a cluster via hearth: `oc patch fournoscluster <name> -n hearth --type=merge -p '{"spec":{"owner":"test"}}'`
- [ ] Verify sentinel FournosJob transitions to Admitted (not Failed)
- [ ] Verify Kueue Workload is created and admitted
- [ ] Verify new jobs targeting the locked cluster stay Pending
- [ ] Unlock cluster: `oc patch fournoscluster <name> -n hearth --type=merge -p '{"spec":{"owner":""}}'`
- [ ] Verify pending jobs get admitted after unlock

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for "lock-only" jobs that reserve cluster resources without executing pipelines.
  * Jobs with `lockOnly` mode require cluster configuration and remain in Admitted phase until deletion.

* **Chores**
  * Updated CRD schema to support lock-only job mode with updated field requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openshift-psap/fournos/pull/89)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->