### PR TITLE
fournos: set a 24h timeout for the task completion

### DIFF
--- a/fournos/core/tekton.py
+++ b/fournos/core/tekton.py
@@ -78,6 +78,11 @@ class TektonClient:
             "metadata": metadata,
             "spec": {
                 "pipelineRef": {"name": pipeline},
+                "timeouts": {
+                    "pipeline": settings.pipeline_timeout,
+                    "tasks": settings.pipeline_tasks_timeout,
+                    "finally": settings.pipeline_finally_timeout,
+                },
                 "taskRunTemplate": {
                     "metadata": {
                         "labels": labels,

--- a/fournos/settings.py
+++ b/fournos/settings.py
@@ -22,6 +22,18 @@ class Settings(BaseSettings):
     resolve_deadline_sec: int = Field(default=300, gt=0)
     resolve_job_template: str = "config/forge/resolve_job.yaml"
     artifact_pvc_size: str = "10Gi"
+    pipeline_timeout: str = Field(
+        default="25h0m0s",
+        description="Default timeout for entire PipelineRun (e.g., '25h0m0s', '90m')",
+    )
+    pipeline_tasks_timeout: str = Field(
+        default="24h0m0s",
+        description="Cumulative timeout across non-finally tasks in PipelineRun (e.g., '24h0m0s', '90m')",
+    )
+    pipeline_finally_timeout: str = Field(
+        default="1h0m0s",
+        description="Default timeout for finally tasks in PipelineRun (e.g., '1h0m0s', '30m')",
+    )
 
 
 settings = Settings()


### PR DESCRIPTION
PipelineRun default is 1h:
```
  spec:
    timeouts:
      pipeline: 1h0m0s
```
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift-psap_forge/129/pull-ci-openshift-psap-forge-main-fournos/2077705564653096960/artifacts/fournos/fournos/artifacts/001__submit_and_wait/artifacts/pipelinerun.yaml

we'll make that configurable from the fjob later

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable timeouts for pipeline runs, including separate limits for the overall pipeline, tasks, and finalization steps.
  * Added default timeout values and support for duration formats such as `25h0m0s` and `90m`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->