### PR TITLE
config/forge/resolve_job.yaml: sync with Forge Tasks

### DIFF
--- a/config/forge/resolve_job.yaml
+++ b/config/forge/resolve_job.yaml
@@ -28,31 +28,56 @@ spec:
           command: ["/bin/bash", "-c"]
           args:
             - |
+              #!/usr/bin/env bash
+
               set -o pipefail
               set -o errexit
               set -o nounset
               set -o errtrace
 
-              export ARTIFACT_DIR=/tmp/artifacts
+              export ARTIFACT_BASE_DIR="$(workspaces.artifacts.path)"
+              export ARTIFACT_DIR="${ARTIFACT_BASE_DIR}/${FOURNOS_STEP_NAME}"
               mkdir -p "${ARTIFACT_DIR}"
 
               exec &> >(tee -a "$ARTIFACT_DIR/run.log")
 
+              # Fetch FournosJob from the hub cluster (in-cluster SA) before
+              # switching KUBECONFIG to the target cluster.
               oc get "fjob/$FJOB_NAME" -n "$FOURNOS_WORKLOAD_NAMESPACE" -oyaml > $ARTIFACT_DIR/fournos_fjob.yaml
 
-              PULL_BASE_SHA=$(cat "$ARTIFACT_DIR/fournos_fjob.yaml" | yq -r .spec.env.PULL_BASE_SHA)
-              if [[ "$PULL_BASE_SHA" != null ]]; then
-                export PULL_BASE_SHA
+              # Check if we have a kubeconfig for target cluster
+              if [[ "$KUBECONFIG_SECRET_PARAM" != "fournos-clusterless-placeholder" && -f "$TARGET_KUBECONFIG" ]]; then
+                echo "Setting up target cluster kubeconfig..."
+                export KUBECONFIG=$TARGET_KUBECONFIG
+                export CLUSTERLESS_MODE="false"
+
               else
-                unset PULL_BASE_SHA
+                if [[ "$KUBECONFIG_SECRET_PARAM" == "fournos-clusterless-placeholder" ]]; then
+                  echo "Running in clusterless mode - no target cluster kubeconfig"
+                else
+                  echo "WARNING: Expected kubeconfig not found at: $TARGET_KUBECONFIG"
+                  echo "Running in clusterless mode as fallback"
+                fi
+                export CLUSTERLESS_MODE="true"
               fi
 
-              PULL_PULL_SHA=$(cat "$ARTIFACT_DIR/fournos_fjob.yaml" | yq -r .spec.env.PULL_PULL_SHA)
-              if [[ "$PULL_PULL_SHA" != null ]]; then
-                export PULL_PULL_SHA
-              else
-                unset PULL_PULL_SHA
-              fi
+              # Function to conditionally export environment variables from FournosJob spec
+              export_env_var_from_fjob() {
+                local var_name="$1"
+                local value=$(cat "$ARTIFACT_DIR/fournos_fjob.yaml" | yq -r ".spec.env.${var_name}")
+                if [[ "$value" != null ]]; then
+                  export "$var_name=$value"
+                  echo "Exported $var_name=$value"
+                else
+                  unset "$var_name" 2>/dev/null || true
+                  echo "Unset $var_name (was null in FournosJob spec)"
+                fi
+              }
+
+              # Export environment variables from FournosJob spec
+              export_env_var_from_fjob PULL_BASE_SHA
+              export_env_var_from_fjob PULL_PULL_SHA
+              export_env_var_from_fjob PULL_NUMBER
 
               if [[ "${PULL_PULL_SHA:-}" ]]; then
                 echo
@@ -60,8 +85,18 @@ spec:
 
                 git -C "$FORGE_HOME" fetch --quiet origin "$PULL_PULL_SHA"
                 git -C "$FORGE_HOME" reset --hard FETCH_HEAD
+
+              elif [[ "${PULL_NUMBER:-}" ]]; then
+                echo
+                echo "Updating to the HEAD commit of PR $PULL_NUMBER ..."
+                commit="refs/pull/$PULL_NUMBER/head"
+
+                git -C "$FORGE_HOME" fetch --quiet origin "$commit"
+                git -C "$FORGE_HOME" reset --hard FETCH_HEAD
+                export PULL_PULL_SHA="$(git rev-parse HEAD)"
+                echo "Setting PULL_PULL_SHA to '$PULL_PULL_SHA'"
               else
-                echo "No PULL_PULL_SHA, using the image commit"
+                echo "No PULL_PULL_SHA nor PULL_NUMBER, using the image commit"
               fi
               git show --quiet
 
@@ -70,7 +105,5 @@ spec:
                 echo "ERROR: invalid .spec.executionEngine.forge.project='$FORGE_PROJECT' in $FOURNOS_WORKLOAD_NAMESPACE/$FJOB_NAME"
                 exit 1
               fi
-
-              export FOURNOS_CI=true
 
               exec bin/run_ci "$FORGE_PROJECT" ci "$FOURNOS_STEP"


### PR DESCRIPTION
sync with https://github.com/openshift-psap/forge/blob/main/fournos/gitops/base/workflows/resolve-job.yaml

This should allow running jobs with PULL_NUMBER and no PULL_PULL_SHA, and use the HEAD commit of the PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact and log collection, including consolidated command output in `run.log`.
  * Improved checkout handling for pull request builds and fallback image commits.
  * Added more reliable target-cluster configuration, including clusterless execution support.
  * Improved environment variable setup and cleanup during job execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->