### PR TITLE
Document Tekton timeout configuration

### DIFF
--- a/Fournos_Design_Document.md
+++ b/Fournos_Design_Document.md
@@ -320,17 +320,19 @@ Completion detection is handled by the operator's timer polling PipelineRun cond
 
 ### Timeouts
 
-Fournos sets PipelineRun-level timeouts when creating the Tekton PipelineRun (see `fournos/core/tekton.py`):
+Fournos sets PipelineRun-level timeouts when creating the Tekton PipelineRun (see [`fournos/core/tekton.py`](fournos/core/tekton.py)). The values are configured via the operator settings in [`fournos/settings.py`](fournos/settings.py):
 
-| Timeout scope | Default | Description |
-| ------------- | ------- | ----------- |
-| `pipeline`    | 25h     | Overall PipelineRun deadline |
-| `tasks`       | 24h     | Maximum wall-clock time for all non-finally tasks |
-| `finally`     | 1h      | Maximum wall-clock time for finally tasks (cleanup, artifact export) |
+| Setting field              | Tekton scope | Default    | Description |
+| -------------------------- | ------------ | ---------- | ----------- |
+| `pipeline_timeout`         | `pipeline`   | `25h0m0s`  | Overall PipelineRun deadline |
+| `pipeline_tasks_timeout`   | `tasks`      | `24h0m0s`  | Maximum wall-clock time for all non-finally tasks |
+| `pipeline_finally_timeout` | `finally`    | `1h0m0s`   | Maximum wall-clock time for finally tasks (cleanup, artifact export) |
 
-**Cluster-wide Tekton default**: Tekton also applies a cluster-wide `default-timeout-minutes` from the `config-defaults` ConfigMap in the `openshift-pipelines` namespace. This default applies to **individual TaskRuns** that do not have an explicit timeout. If this value is lower than the PipelineRun `tasks` timeout, TaskRuns will be killed early even though the PipelineRun allows more time.
+These are Go duration strings and can be overridden via environment variables (`FOURNOS_PIPELINE_TIMEOUT`, `FOURNOS_PIPELINE_TASKS_TIMEOUT`, `FOURNOS_PIPELINE_FINALLY_TIMEOUT`) or by modifying the operator Deployment.
 
-To prevent this, set the cluster-wide default higher than the PipelineRun task timeout:
+**Cluster-wide Tekton default**: Tekton also applies a cluster-wide `default-timeout-minutes` from the `config-defaults` ConfigMap in the `openshift-pipelines` namespace. This default applies to **individual TaskRuns** that do not have an explicit timeout. If this value is lower than `pipeline_tasks_timeout`, TaskRuns will be killed early even though the PipelineRun allows more time.
+
+To prevent this, set the cluster-wide default higher than `pipeline_tasks_timeout`:
 
 ```bash
 oc patch configmap config-defaults -n openshift-pipelines \

--- a/Fournos_Design_Document.md
+++ b/Fournos_Design_Document.md
@@ -318,6 +318,27 @@ Every Pipeline must carry a `fournos.dev/resolve-image` annotation with the full
 
 Completion detection is handled by the operator's timer polling PipelineRun conditions — no callback task is needed.
 
+### Timeouts
+
+Fournos sets PipelineRun-level timeouts when creating the Tekton PipelineRun (see `fournos/core/tekton.py`):
+
+| Timeout scope | Default | Description |
+| ------------- | ------- | ----------- |
+| `pipeline`    | 25h     | Overall PipelineRun deadline |
+| `tasks`       | 24h     | Maximum wall-clock time for all non-finally tasks |
+| `finally`     | 1h      | Maximum wall-clock time for finally tasks (cleanup, artifact export) |
+
+**Cluster-wide Tekton default**: Tekton also applies a cluster-wide `default-timeout-minutes` from the `config-defaults` ConfigMap in the `openshift-pipelines` namespace. This default applies to **individual TaskRuns** that do not have an explicit timeout. If this value is lower than the PipelineRun `tasks` timeout, TaskRuns will be killed early even though the PipelineRun allows more time.
+
+To prevent this, set the cluster-wide default higher than the PipelineRun task timeout:
+
+```bash
+oc patch configmap config-defaults -n openshift-pipelines \
+  -p '{"data":{"default-timeout-minutes":"5940"}}'   # 99 hours
+```
+
+This ensures individual TaskRuns never hit the cluster default before the PipelineRun-level timeout.
+
 ## 9. Kueue configuration
 
 [config/kueue-cluster-config.yaml](config/kueue-cluster-config.yaml):


### PR DESCRIPTION
Add a Timeouts subsection to Section 8 (Tekton Pipelines and Tasks) explaining the PipelineRun-level timeouts set by Fournos and the cluster-wide default-timeout-minutes ConfigMap that can override individual TaskRun timeouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Timeouts” section covering how Fournos sets PipelineRun, task, and finally-task timeout behavior.
  * Documented Tekton’s cluster-wide `default-timeout-minutes` behavior for TaskRuns without explicit timeouts.
  * Included an example `oc patch` command to adjust the default timeout to avoid early TaskRun termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->