### PR TITLE
feat: add scheduled and recurring job support

### DIFF
--- a/Fournos_Design_Document.md
+++ b/Fournos_Design_Document.md
@@ -55,6 +55,8 @@ Jobs are submitted as `FournosJob` custom resources ([manifests/crd.yaml](manife
 | `spec.priority`              | no           | Kueue WorkloadPriorityClass name                                                                 |
 | `spec.secretRefs`            | no           | Vault-synced K8s Secret names (`vault-<entry>`) to mount into the pipeline. Populated by the execution engine during the Resolving phase. Each must be a K8s Secret with `fournos.dev/vault-entry=true` in `FOURNOS_SECRETS_NAMESPACE`. During the Admitted phase the operator copies them into the operator namespace and mounts them as a projected volume at `/var/run/secrets/fournos/<entry-name>/`. |
 | `spec.exclusive`             | no (default `true`) | If `true`, locks the target cluster so no other FournosJob can run there. Requires `spec.cluster`. Hardware is optional — when omitted the Workload only requests cluster-slot resources for locking. |
+| `spec.scheduledStartTime`    | no           | ISO 8601 UTC timestamp. When set, the job stays in `Scheduled` phase until this time, then proceeds to `Resolving`. Mutually exclusive with `schedule`. |
+| `spec.schedule`              | no           | Cron expression for recurring execution (e.g. `0 20 * * *`). The job enters `Recurring` phase and creates child FournosJobs on each cron tick, labeled with `fournos.dev/recurring-parent`. Mutually exclusive with `scheduledStartTime`. |
 | `spec.shutdown`              | no           | Shutdown action: `Stop` (graceful, runs finally tasks) or `Terminate` (immediate, skips finally tasks). Both wait for the PipelineRun to finish before releasing Kueue quota. |
 
 
@@ -69,11 +71,12 @@ The operator writes status to `.status`:
 
 | Field          | Description                                                 |
 | -------------- | ----------------------------------------------------------- |
-| `phase`        | `Resolving` → `Pending` → `Admitted` → `Running` → `Succeeded` / `Failed` / `Stopping` → `Stopped` |
+| `phase`        | [`Scheduled` →] [`Recurring` ↻] `Resolving` → `Pending` → `Admitted` → `Running` → `Succeeded` / `Failed` / `Stopping` → `Stopped` |
 | `cluster`      | Cluster assigned by Kueue                                   |
 | `pipelineRun`  | Name of the Tekton PipelineRun                              |
 | `dashboardURL` | Tekton Dashboard link (if configured)                       |
 | `message`      | Error details on failure                                    |
+| `lastScheduledTime` | For recurring jobs, the timestamp when the last child job was created |
 
 
 ### Example
@@ -140,6 +143,18 @@ Clusterless jobs (`clusterless: true`) bypass Kueue entirely and run on the hub 
 - Must use `exclusive: false`
 - Cannot use `lockOnly: true`
 - No kubeconfig passed to execution environment
+
+### Scheduled and recurring jobs
+
+The operator supports two forms of deferred execution, both configured at the CRD level:
+
+**One-time scheduled jobs** (`spec.scheduledStartTime`): The job enters `Scheduled` phase and waits until the specified ISO 8601 timestamp. When the time is reached, the operator resets the status and proceeds to the normal `Resolving` → `Pending` → `Admitted` → `Running` flow. If the timestamp is invalid, the job immediately transitions to `Failed`.
+
+**Recurring jobs** (`spec.schedule`): The job enters `Recurring` phase and acts as a template. On each cron tick (parsed by [`croniter`](https://github.com/kiorky/croniter)), the operator deep-copies the parent spec (stripping `schedule` and `scheduledStartTime`), creates a child FournosJob CR with `generateName`, and labels it with `fournos.dev/recurring-parent: <parent-name>`. The parent's `status.lastScheduledTime` tracks the last trigger. If the cron expression is invalid, the job immediately transitions to `Failed`.
+
+A manual trigger is supported via the `fournos.dev/trigger-now` annotation — setting it to `"true"` creates a child job immediately and resets the annotation to `"false"`.
+
+The two fields are mutually exclusive — setting both results in validation failure.
 
 ### Exclusive cluster locking
 
@@ -211,7 +226,9 @@ sequenceDiagram
 
 
 
-1. **on_create**: Operator validates the spec (cluster exists if specified, `exclusive` requires `cluster` — and `exclusive` defaults to `true`). If `spec.shutdown` is set (`Stop` or `Terminate`), immediately sets `phase=Stopped`. Otherwise sets `phase=Resolving`.
+1. **on_create**: Operator validates the spec (cluster exists if specified, `exclusive` requires `cluster` — and `exclusive` defaults to `true`). If `spec.scheduledStartTime` and `spec.schedule` are both set, fails immediately. If `spec.schedule` is set with a valid cron expression, sets `phase=Recurring`. If `spec.scheduledStartTime` is set and in the future, sets `phase=Scheduled`. If `spec.shutdown` is set (`Stop` or `Terminate`), immediately sets `phase=Stopped`. Otherwise sets `phase=Resolving`.
+1a. **timer (Scheduled)**: Waits until `scheduledStartTime` is reached, then resets the status and re-enters the `on_create` flow (which sets `phase=Resolving`). If `scheduledStartTime` is unparseable, sets `phase=Failed`.
+1b. **timer (Recurring)**: On each cron tick (or when `fournos.dev/trigger-now` annotation is `"true"`), deep-copies the parent spec (stripping `schedule`/`scheduledStartTime`), creates a child FournosJob with `generateName`, labels it with `fournos.dev/recurring-parent`, and updates `status.lastScheduledTime`.
 2. **timer (Resolving)**: Reads the `fournos.dev/resolve-image` annotation from the Tekton Pipeline referenced by `spec.pipeline` and launches a resolve K8s Job using that image. The resolve Job patches the FournosJob spec with `hardware` (if not user-provided) and `secretRefs`. Polls the Job for completion. On success, reads the FournosJob spec, validates hardware (GPU type checked against Kueue; hardware is optional for exclusive+cluster jobs), validates `secretRefs` against Vault secrets, creates the Kueue Workload (exclusive jobs request all 100 `fournos/cluster-slot` units; non-exclusive jobs request 1), and sets `phase=Pending`. Failed resolve Jobs are preserved for debugging.
 3. **timer (Pending)**: Polls the Workload for Kueue admission. On admission, extracts the assigned cluster and sets `phase=Admitted`.
 4. **timer (Admitted)**: Reads `secretRefs` from the FournosJob spec, copies each referenced secret from `secrets_namespace` into the operator namespace (per-job name `<fjob-name>-<ref>`, with `ownerReferences` for automatic cleanup), resolves the kubeconfig Secret, creates the Tekton PipelineRun with `FJOB_NAME` + `FOURNOS_WORKLOAD_NAMESPACE` params (so the execution engine can look up the full spec), a projected `vault-secrets` volume mounting all copied secrets at `/var/run/secrets/fournos/<entry-name>/`, and `ownerReferences` pointing at the FournosJob, sets `phase=Running`.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ oc delete FournosJob -n $FOURNOS_WORKLOAD_NAMESPACE <name>      # cleanup
 | `spec.secretRefs` | no | Vault-synced K8s Secret names (prefixed with `vault-`) to mount into the pipeline. Populated by the execution engine during the Resolving phase. The operator validates each name in `FOURNOS_SECRETS_NAMESPACE`, copies the secrets into the operator namespace, and mounts them as a projected volume at `/var/run/secrets/fournos/<entry-name>/`. |
 | `spec.exclusive` | no (default `true`) | If `true`, locks the target cluster so no other FournosJob can run there. Requires `spec.cluster`. Hardware is optional — when omitted the Workload only requests cluster-slot resources for locking. |
 | `spec.clusterless` | no (default `false`) | If `true`, runs without cluster access — no kubeconfig is passed to the execution environment. Cannot be combined with `cluster` or `exclusive: true`. Hardware specifications are optional — if omitted, the job runs on hub cluster resources without Kueue hardware scheduling. |
+| `spec.scheduledStartTime` | no | ISO 8601 UTC timestamp (e.g. `2026-08-18T15:00:00Z`). When set, the job stays in `Scheduled` phase until this time, then proceeds to `Resolving`. Mutually exclusive with `schedule`. |
+| `spec.schedule` | no | Cron expression for recurring execution (e.g. `0 20 * * *`). The job enters `Recurring` phase and the operator creates child FournosJob CRs on each cron tick, labeled with `fournos.dev/recurring-parent`. Mutually exclusive with `scheduledStartTime`. |
 | `spec.shutdown` | no | Shutdown action: `Stop` cancels gracefully (Tekton `CancelledRunFinally` — runs `finally` tasks); `Terminate` cancels immediately (Tekton `Cancelled` — skips `finally` tasks). Both wait for the PipelineRun to finish before releasing Kueue quota. |
 
 \* `spec.hardware` is optional for all jobs except those requiring explicit GPU 
@@ -111,7 +113,8 @@ The operator writes status to `.status`:
 
 | Field | Description |
 |---|---|
-| `phase` | `Resolving` → `Pending` → `Admitted` → `Running` → `Succeeded` / `Failed` / `Stopping` → `Stopped` |
+| `phase` | [`Scheduled` →] [`Recurring` ↻] `Resolving` → `Pending` → `Admitted` → `Running` → `Succeeded` / `Failed` / `Stopping` → `Stopped` |
+| `lastScheduledTime` | For recurring jobs, the timestamp when the last child job was created |
 | `cluster` | Cluster assigned by Kueue (or `[clusterless]` for clusterless jobs) |
 | `pipelineRun` | Name of the Tekton PipelineRun |
 | `dashboardURL` | Tekton Dashboard link (if configured) |
@@ -158,6 +161,73 @@ Resolving → Admitted → Running → Succeeded/Failed
 - Must use `exclusive: false`
 - Cannot use `lockOnly: true`
 - No target cluster kubeconfig available to execution environment
+
+## Scheduled and Recurring Jobs
+
+### One-time scheduled jobs
+
+Set `spec.scheduledStartTime` to defer execution to a future time. The job
+enters `Scheduled` phase and automatically transitions to `Resolving` once the
+time is reached. When `scheduledStartTime` is omitted or in the past, the job
+starts immediately.
+
+```yaml
+apiVersion: fournos.dev/v1
+kind: FournosJob
+metadata:
+  generateName: deferred-bench-
+spec:
+  owner: perf-team
+  scheduledStartTime: "2026-08-18T15:00:00Z"
+  cluster: cluster-1
+  executionEngine:
+    forge:
+      project: llm-d
+      args: [cks]
+```
+
+**Lifecycle:** `Scheduled` → `Resolving` → `Pending` → `Admitted` → `Running` → `Succeeded`/`Failed`
+
+### Recurring jobs
+
+Set `spec.schedule` with a cron expression to create a recurring job template.
+The job enters `Recurring` phase and the operator creates child FournosJob CRs
+on each cron tick. The parent stays in `Recurring` phase indefinitely.
+
+```yaml
+apiVersion: fournos.dev/v1
+kind: FournosJob
+metadata:
+  name: nightly-bench
+spec:
+  owner: perf-team
+  schedule: "0 20 * * *"
+  cluster: cluster-1
+  executionEngine:
+    forge:
+      project: llm-d
+      args: [cks]
+```
+
+Child jobs are labeled with `fournos.dev/recurring-parent` for easy querying:
+
+```bash
+kubectl get fjobs -l fournos.dev/recurring-parent=nightly-bench
+```
+
+To manually trigger a child job outside the cron schedule:
+
+```bash
+kubectl annotate fjob nightly-bench fournos.dev/trigger-now=true
+```
+
+The operator creates a child immediately and resets the annotation to `false`.
+
+To stop recurring execution, delete the parent job.
+
+**Restrictions:**
+- `scheduledStartTime` and `schedule` are mutually exclusive
+- Invalid cron expressions or timestamps fail the job immediately
 
 ## Local development
 

--- a/fournos/core/constants.py
+++ b/fournos/core/constants.py
@@ -4,12 +4,16 @@ LABEL_MANAGED_BY = "app.kubernetes.io/managed-by"
 LABEL_JOB_NAME = "fournos.dev/job-name"
 LABEL_EXCLUSIVE_CLUSTER = "fournos.dev/exclusive-cluster"
 LABEL_VAULT_ENTRY = "fournos.dev/vault-entry"
+LABEL_RECURRING_PARENT = "fournos.dev/recurring-parent"
+ANNOTATION_TRIGGER_NOW = "fournos.dev/trigger-now"
 
 CLUSTER_SLOT_RESOURCE = "fournos/cluster-slot"
 MAX_CLUSTER_SLOTS = 100
 
 
 class Phase(StrEnum):
+    SCHEDULED = "Scheduled"
+    RECURRING = "Recurring"
     RESOLVING = "Resolving"
     PENDING = "Pending"
     ADMITTED = "Admitted"

--- a/fournos/handlers/__init__.py
+++ b/fournos/handlers/__init__.py
@@ -6,7 +6,12 @@ from .execution import (
     reconcile_running,
     reconcile_stopping,
 )
-from .lifecycle import on_create, reconcile_pending
+from .lifecycle import (
+    on_create,
+    reconcile_pending,
+    reconcile_recurring,
+    reconcile_scheduled,
+)
 from .resolving import reconcile_resolving
 
 __all__ = [
@@ -14,7 +19,9 @@ __all__ = [
     "on_create",
     "reconcile_admitted",
     "reconcile_pending",
+    "reconcile_recurring",
     "reconcile_resolving",
     "reconcile_running",
+    "reconcile_scheduled",
     "reconcile_stopping",
 ]

--- a/fournos/handlers/lifecycle.py
+++ b/fournos/handlers/lifecycle.py
@@ -1,19 +1,26 @@
-"""Lifecycle handlers — on_create and reconcile_pending.
+"""Lifecycle handlers — on_create, reconcile_scheduled, reconcile_recurring,
+and reconcile_pending.
 
-Covers the early phases of a FournosJob: creation and pending admission
+Covers the early phases of a FournosJob: creation, optional deferred
+scheduling, recurring cron-based scheduling, and pending admission
 through Kueue.  Exclusive locking is handled entirely by Kueue via
 cluster-slot resources.
 """
 
 from __future__ import annotations
 
+import copy
 import logging
+from datetime import UTC, datetime
 
+from croniter import croniter
 from kubernetes import client as k8s_client
 
 from fournos.core.constants import (
+    ANNOTATION_TRIGGER_NOW,
     CLUSTER_SLOT_RESOURCE,
     LABEL_EXCLUSIVE_CLUSTER,
+    LABEL_RECURRING_PARENT,
     LOCK_HOLDING_PHASES,
     Phase,
 )
@@ -46,6 +53,37 @@ def on_create(spec, name, namespace, status, patch, body):
         patch.status["phase"] = Phase.STOPPED
         patch.status["message"] = "Job stopped by user"
         logger.info("Job %s: created with shutdown=%s, skipping", name, shutdown)
+        return
+
+    cron_expr = spec.get("schedule")
+    scheduled_time = _parse_scheduled_time(spec)
+
+    if isinstance(scheduled_time, str):
+        patch.status["phase"] = Phase.FAILED
+        patch.status["message"] = scheduled_time
+        return
+
+    if cron_expr and scheduled_time is not None:
+        patch.status["phase"] = Phase.FAILED
+        patch.status["message"] = (
+            "'schedule' and 'scheduledStartTime' are mutually exclusive"
+        )
+        return
+
+    if cron_expr:
+        if not croniter.is_valid(cron_expr):
+            patch.status["phase"] = Phase.FAILED
+            patch.status["message"] = f"Invalid cron expression: {cron_expr}"
+            return
+        patch.status["phase"] = Phase.RECURRING
+        patch.status["message"] = f"Recurring schedule: {cron_expr}"
+        logger.info("Job %s: phase=Recurring, schedule=%s", name, cron_expr)
+        return
+
+    if scheduled_time is not None and datetime.now(UTC) < scheduled_time:
+        patch.status["phase"] = Phase.SCHEDULED
+        patch.status["message"] = f"Scheduled to start at {scheduled_time.isoformat()}"
+        logger.info("Job %s: phase=Scheduled, startTime=%s", name, scheduled_time)
         return
 
     cluster = spec.get("cluster")
@@ -109,6 +147,132 @@ def on_create(spec, name, namespace, status, patch, body):
     patch.status["phase"] = Phase.RESOLVING
     patch.status["message"] = "Resolving job requirements"
     logger.info("Job %s: phase=Resolving", name)
+
+
+# ---------------------------------------------------------------------------
+# HELPERS
+# ---------------------------------------------------------------------------
+
+
+def _parse_scheduled_time(spec) -> datetime | str | None:
+    """Return the parsed scheduledStartTime, None if absent, or an error string if invalid."""
+    raw = spec.get("scheduledStartTime")
+    if raw is None:
+        return None
+    try:
+        ts = datetime.fromisoformat(raw)
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=UTC)
+        return ts
+    except (ValueError, TypeError):
+        return f"Invalid scheduledStartTime: {raw!r}"
+
+
+# ---------------------------------------------------------------------------
+# SCHEDULED — wait until scheduledStartTime is reached
+# ---------------------------------------------------------------------------
+
+
+def reconcile_scheduled(spec, name, namespace, status, patch, body):
+    """Transition from Scheduled to the normal on_create flow once the time is reached."""
+    scheduled_time = _parse_scheduled_time(spec)
+    if isinstance(scheduled_time, str):
+        patch.status["phase"] = Phase.FAILED
+        patch.status["message"] = scheduled_time
+        return
+    if isinstance(scheduled_time, datetime) and datetime.now(UTC) < scheduled_time:
+        return
+
+    logger.info("Job %s: scheduled time reached, starting job", name)
+    on_create(spec, name, namespace, {}, patch, body)
+
+
+# ---------------------------------------------------------------------------
+# RECURRING — create child FournosJobs on each cron tick
+# ---------------------------------------------------------------------------
+
+
+def reconcile_recurring(spec, name, namespace, status, patch, body):
+    """Create a child FournosJob when the next cron tick is reached or trigger-now is set."""
+    cron_expr = spec.get("schedule")
+    if not cron_expr:
+        return
+
+    now = datetime.now(UTC)
+    annotations = body.get("metadata", {}).get("annotations") or {}
+    trigger_now = annotations.get(ANNOTATION_TRIGGER_NOW, "").lower() == "true"
+
+    if not trigger_now:
+        creation_time = datetime.fromisoformat(body["metadata"]["creationTimestamp"])
+
+        last_raw = status.get("lastScheduledTime")
+        if last_raw:
+            try:
+                base_time = datetime.fromisoformat(last_raw)
+                if base_time.tzinfo is None:
+                    base_time = base_time.replace(tzinfo=UTC)
+            except (ValueError, TypeError):
+                logger.warning(
+                    "Job %s: corrupt lastScheduledTime %r, falling back to creationTimestamp",
+                    name,
+                    last_raw,
+                )
+                base_time = creation_time
+        else:
+            base_time = creation_time
+
+        next_time = croniter(cron_expr, base_time).get_next(datetime)
+        if next_time.tzinfo is None:
+            next_time = next_time.replace(tzinfo=UTC)
+
+        if now < next_time:
+            return
+
+    child_spec = copy.deepcopy(dict(spec))
+    child_spec.pop("schedule", None)
+    child_spec.pop("scheduledStartTime", None)
+
+    safe_name = name[:58].rstrip("-")
+    child_body = {
+        "apiVersion": f"{CRD_GROUP}/{CRD_VERSION}",
+        "kind": "FournosJob",
+        "metadata": {
+            "generateName": f"{safe_name}-",
+            "namespace": namespace,
+            "labels": {
+                LABEL_RECURRING_PARENT: name,
+            },
+        },
+        "spec": child_spec,
+    }
+
+    custom = k8s_client.CustomObjectsApi()
+    try:
+        created = custom.create_namespaced_custom_object(
+            CRD_GROUP,
+            CRD_VERSION,
+            namespace,
+            "fournosjobs",
+            child_body,
+        )
+        child_name = created["metadata"]["name"]
+        patch.status["lastScheduledTime"] = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+        patch.status["message"] = (
+            f"Recurring schedule: {cron_expr} (last child: {child_name})"
+        )
+        if trigger_now:
+            patch.meta.setdefault("annotations", {})[ANNOTATION_TRIGGER_NOW] = "false"
+            logger.info("Job %s: trigger-now created child %s", name, child_name)
+        else:
+            logger.info(
+                "Job %s: created recurring child %s (next after %s)",
+                name,
+                child_name,
+                next_time.isoformat(),
+            )
+    except k8s_client.exceptions.ApiException as exc:
+        logger.error("Job %s: failed to create recurring child: %s", name, exc.reason)
+        patch.status["message"] = f"Failed to create child job: {exc.reason}"
 
 
 def _create_lock_workload(spec, name, patch, body):

--- a/fournos/operator.py
+++ b/fournos/operator.py
@@ -93,6 +93,8 @@ def on_create(spec, name, namespace, status, patch, body, **_):
     when=lambda status, **_: (
         status.get("phase")
         in (
+            Phase.SCHEDULED,
+            Phase.RECURRING,
             Phase.RESOLVING,
             Phase.PENDING,
             Phase.ADMITTED,
@@ -113,7 +115,11 @@ def reconcile(spec, name, namespace, status, patch, body, **_):
         handlers.handle_shutdown(name, status, patch, shutdown)
         return
 
-    if phase == Phase.RESOLVING:
+    if phase == Phase.SCHEDULED:
+        handlers.reconcile_scheduled(spec, name, namespace, status, patch, body)
+    elif phase == Phase.RECURRING:
+        handlers.reconcile_recurring(spec, name, namespace, status, patch, body)
+    elif phase == Phase.RESOLVING:
         handlers.reconcile_resolving(spec, name, status, patch, body)
     elif phase == Phase.PENDING:
         handlers.reconcile_pending(spec, name, status, patch, body)

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -32,6 +32,14 @@ spec:
           type: boolean
           jsonPath: .spec.exclusive
           priority: 1
+        - name: Scheduled For
+          type: string
+          jsonPath: .spec.scheduledStartTime
+          priority: 1
+        - name: Schedule
+          type: string
+          jsonPath: .spec.schedule
+          priority: 1
         - name: Phase
           type: string
           jsonPath: .status.phase
@@ -136,6 +144,23 @@ spec:
                     stays Admitted indefinitely until deleted.
                 priority:
                   type: string
+                scheduledStartTime:
+                  type: string
+                  format: date-time
+                  description: >-
+                    If set, the job stays in Scheduled phase until this
+                    UTC timestamp is reached, then proceeds to Resolving.
+                    ISO 8601 format (e.g. "2026-08-18T15:00:00Z").
+                    When omitted the job starts immediately.
+                    Mutually exclusive with 'schedule'.
+                schedule:
+                  type: string
+                  description: >-
+                    Cron expression for recurring execution (e.g.
+                    "0 20 * * *" for every day at 20:00 UTC). When set,
+                    this job acts as a template in Recurring phase and
+                    the operator creates child FournosJob CRs on each
+                    cron tick. Mutually exclusive with 'scheduledStartTime'.
                 shutdown:
                   type: string
                   enum:
@@ -153,6 +178,8 @@ spec:
                 phase:
                   type: string
                   enum:
+                    - Scheduled
+                    - Recurring
                     - Resolving
                     - Pending
                     - Admitted
@@ -169,6 +196,12 @@ spec:
                   type: string
                 message:
                   type: string
+                lastScheduledTime:
+                  type: string
+                  format: date-time
+                  description: >-
+                    For recurring jobs, the timestamp when the last child
+                    job was created. Used to determine the next cron tick.
                 engineStatus:
                   type: object
                   description: >-

--- a/manifests/rbac/role_fournos.yaml
+++ b/manifests/rbac/role_fournos.yaml
@@ -6,7 +6,7 @@ metadata:
 rules:
   - apiGroups: ["fournos.dev"]
     resources: ["fournosjobs", "fournosjobs/status", "fournosjobs/finalizers"]
-    verbs: ["get", "list", "watch", "patch", "update"]
+    verbs: ["create", "get", "list", "watch", "patch", "update"]
   - apiGroups: ["kueue.x-k8s.io"]
     resources: ["workloads"]
     verbs: ["create", "get", "list", "watch", "patch", "delete"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.4.2"
 description = "Benchmark job operator — Kubernetes CRD + Kueue + Tekton"
 requires-python = ">=3.11"
 dependencies = [
+    "croniter>=5.0",
     "kopf>=1.37",
     "kubernetes>=31.0",
     "pydantic-settings>=2.7",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,9 +44,8 @@ def k8s():
     return client.CustomObjectsApi()
 
 
-@pytest.fixture(autouse=True)
-def _clean_before_test(k8s):
-    """Wipe all FournosJobs (and their child resources) for a deterministic state."""
+def _wipe_all_jobs(k8s) -> None:
+    """Delete all FournosJobs and wait for them to be gone."""
     jobs = k8s.list_namespaced_custom_object(GROUP, VERSION, NAMESPACE, PLURAL)
     for job in jobs.get("items", []):
         name = job["metadata"]["name"]
@@ -73,6 +72,14 @@ def _clean_before_test(k8s):
     _kubectl_delete_all("pipelineruns.tekton.dev")
     _kubectl_delete_all("workloads.kueue.x-k8s.io")
     _kubectl_delete_all("jobs.batch")
+
+
+@pytest.fixture(autouse=True)
+def _clean_around_test(k8s):
+    """Wipe all FournosJobs (and their child resources) before and after each test."""
+    _wipe_all_jobs(k8s)
+    yield
+    _wipe_all_jobs(k8s)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_deferred_scheduling.py
+++ b/tests/test_deferred_scheduling.py
@@ -1,0 +1,324 @@
+"""Deferred scheduling tests — one-time scheduledStartTime and recurring cron schedule.
+
+Tests cover:
+  - Scheduled jobs entering Scheduled phase and transitioning after the time is reached
+  - Past scheduledStartTime starting immediately
+  - Invalid scheduledStartTime failing the job
+  - Mutual exclusivity of schedule and scheduledStartTime
+  - Invalid cron expression failing the job
+  - Recurring jobs entering Recurring phase and creating children
+  - trigger-now annotation creating a child immediately
+  - Backward compatibility: no scheduling fields behaves as before
+"""
+
+import subprocess
+import time
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from kubernetes.client.exceptions import ApiException
+
+from fournos.core.constants import LABEL_RECURRING_PARENT, Phase
+from tests.conftest import (
+    GROUP,
+    NAMESPACE,
+    PLURAL,
+    VERSION,
+    create_job,
+    get_job,
+    job_status_summary,
+    poll_phase,
+)
+
+
+def _spec(**overrides) -> dict:
+    """Build a clusterless base spec, merging in *overrides*."""
+    base = {
+        "clusterless": True,
+        "exclusive": False,
+        "pipeline": "forge-test-only",
+        "executionEngine": {
+            "forge": {
+                "project": "skeleton",
+                "args": [],
+            }
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Validation tests (fast — no waiting for timers)
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_scheduled_start_time(k8s):
+    """Invalid scheduledStartTime format → rejected by CRD validation (422)."""
+    with pytest.raises(ApiException) as exc_info:
+        create_job(k8s, "test-bad-timestamp", _spec(scheduledStartTime="not-a-date"))
+
+    assert exc_info.value.status == 422, (
+        f"Expected 422 Unprocessable Entity, got {exc_info.value.status}"
+    )
+    assert "scheduledStartTime" in (exc_info.value.body or ""), (
+        f"Error body should mention scheduledStartTime, got: {exc_info.value.body!r}"
+    )
+
+
+def test_invalid_cron_expression(k8s):
+    """Invalid cron expression → immediate Failed."""
+    create_job(k8s, "test-bad-cron", _spec(schedule="not a cron"))
+
+    phase = poll_phase(
+        k8s,
+        "test-bad-cron",
+        terminal={Phase.FAILED},
+        timeout=15,
+    )
+    assert phase == Phase.FAILED, job_status_summary(k8s, "test-bad-cron")
+
+    job = get_job(k8s, "test-bad-cron")
+    msg = job["status"]["message"].lower()
+    assert "invalid" in msg and "cron" in msg, (
+        f"Failure message should mention invalid cron, got: {msg!r}"
+    )
+
+
+def test_schedule_and_scheduled_start_time_mutual_exclusion(k8s):
+    """Setting both schedule and scheduledStartTime → immediate Failed."""
+    future = (datetime.now(UTC) + timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    create_job(
+        k8s,
+        "test-mutual-exclusive",
+        _spec(schedule="0 20 * * *", scheduledStartTime=future),
+    )
+
+    phase = poll_phase(
+        k8s,
+        "test-mutual-exclusive",
+        terminal={Phase.FAILED},
+        timeout=15,
+    )
+    assert phase == Phase.FAILED, job_status_summary(k8s, "test-mutual-exclusive")
+
+    job = get_job(k8s, "test-mutual-exclusive")
+    msg = job["status"]["message"].lower()
+    assert "mutually exclusive" in msg, (
+        f"Failure message should mention 'mutually exclusive', got: {msg!r}"
+    )
+
+
+def test_no_scheduling_fields_backward_compat(k8s):
+    """Job without scheduledStartTime or schedule enters the normal lifecycle."""
+    create_job(k8s, "test-no-sched", _spec())
+
+    phase = poll_phase(
+        k8s,
+        "test-no-sched",
+        terminal={Phase.RESOLVING, Phase.ADMITTED, Phase.RUNNING, Phase.SUCCEEDED},
+        timeout=30,
+    )
+    assert phase != Phase.SCHEDULED, (
+        f"Job without scheduling fields should not enter Scheduled phase, got {phase!r}"
+    )
+    assert phase != Phase.RECURRING, (
+        f"Job without scheduling fields should not enter Recurring phase, got {phase!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scheduled start time tests
+# ---------------------------------------------------------------------------
+
+
+def test_scheduled_start_time_future(k8s):
+    """Job with future scheduledStartTime enters Scheduled phase, then transitions."""
+    start = (datetime.now(UTC) + timedelta(seconds=30)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    create_job(k8s, "test-sched-future", _spec(scheduledStartTime=start))
+
+    phase = poll_phase(
+        k8s,
+        "test-sched-future",
+        terminal={Phase.SCHEDULED},
+        timeout=15,
+    )
+    assert phase == Phase.SCHEDULED, job_status_summary(k8s, "test-sched-future")
+
+    job = get_job(k8s, "test-sched-future")
+    assert "scheduled" in job["status"]["message"].lower(), (
+        f"Scheduled job should have schedule message, got: {job['status']['message']!r}"
+    )
+
+    phase = poll_phase(
+        k8s,
+        "test-sched-future",
+        terminal={
+            Phase.RESOLVING,
+            Phase.ADMITTED,
+            Phase.RUNNING,
+            Phase.SUCCEEDED,
+            Phase.FAILED,
+        },
+        timeout=60,
+    )
+    assert phase != Phase.SCHEDULED, (
+        f"Job should have left Scheduled phase after start time, got {phase!r}"
+    )
+
+
+def test_scheduled_start_time_past(k8s):
+    """Job with past scheduledStartTime skips Scheduled phase and starts immediately."""
+    past = (datetime.now(UTC) - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    create_job(k8s, "test-sched-past", _spec(scheduledStartTime=past))
+
+    phase = poll_phase(
+        k8s,
+        "test-sched-past",
+        terminal={
+            Phase.RESOLVING,
+            Phase.ADMITTED,
+            Phase.RUNNING,
+            Phase.SUCCEEDED,
+            Phase.FAILED,
+        },
+        timeout=30,
+    )
+    assert phase != Phase.SCHEDULED, (
+        f"Past scheduledStartTime should skip Scheduled phase, got {phase!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Recurring schedule tests
+# ---------------------------------------------------------------------------
+
+
+def test_recurring_enters_recurring_phase(k8s):
+    """Job with valid cron expression enters Recurring phase."""
+    create_job(k8s, "test-recurring-phase", _spec(schedule="0 0 1 1 *"))
+
+    phase = poll_phase(
+        k8s,
+        "test-recurring-phase",
+        terminal={Phase.RECURRING},
+        timeout=15,
+    )
+    assert phase == Phase.RECURRING, job_status_summary(k8s, "test-recurring-phase")
+
+    job = get_job(k8s, "test-recurring-phase")
+    msg = job["status"]["message"]
+    assert "recurring" in msg.lower(), (
+        f"Recurring job message should mention 'recurring', got: {msg!r}"
+    )
+
+
+def test_trigger_now_creates_child(k8s):
+    """Setting fournos.dev/trigger-now=true creates a child FournosJob immediately."""
+    create_job(k8s, "test-trigger-now", _spec(schedule="0 0 1 1 *"))
+
+    poll_phase(
+        k8s,
+        "test-trigger-now",
+        terminal={Phase.RECURRING},
+        timeout=15,
+    )
+
+    subprocess.run(
+        [
+            "kubectl",
+            "annotate",
+            "fjob",
+            "test-trigger-now",
+            "fournos.dev/trigger-now=true",
+            "-n",
+            NAMESPACE,
+            "--overwrite",
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    deadline = time.monotonic() + 30
+    children = []
+    while time.monotonic() < deadline:
+        jobs = k8s.list_namespaced_custom_object(GROUP, VERSION, NAMESPACE, PLURAL)
+        children = [
+            j
+            for j in jobs["items"]
+            if j.get("metadata", {}).get("labels", {}).get(LABEL_RECURRING_PARENT)
+            == "test-trigger-now"
+        ]
+        if children:
+            break
+        time.sleep(2)
+
+    assert len(children) >= 1, (
+        "trigger-now should have created at least one child FournosJob"
+    )
+
+    child = children[0]
+    child_spec = child["spec"]
+    assert "schedule" not in child_spec, (
+        "Child job should not inherit the 'schedule' field"
+    )
+    assert "scheduledStartTime" not in child_spec, (
+        "Child job should not inherit the 'scheduledStartTime' field"
+    )
+
+    parent = get_job(k8s, "test-trigger-now")
+    assert parent["status"].get("lastScheduledTime"), (
+        "Parent job should have lastScheduledTime set after triggering"
+    )
+    parent_annotations = parent.get("metadata", {}).get("annotations", {})
+    assert parent_annotations.get("fournos.dev/trigger-now") != "true", (
+        "trigger-now annotation should be reset after triggering"
+    )
+
+
+def test_recurring_child_labeled_correctly(k8s):
+    """Child jobs from recurring parent carry the fournos.dev/recurring-parent label."""
+    create_job(k8s, "test-child-label", _spec(schedule="0 0 1 1 *"))
+
+    poll_phase(
+        k8s,
+        "test-child-label",
+        terminal={Phase.RECURRING},
+        timeout=15,
+    )
+
+    subprocess.run(
+        [
+            "kubectl",
+            "annotate",
+            "fjob",
+            "test-child-label",
+            "fournos.dev/trigger-now=true",
+            "-n",
+            NAMESPACE,
+            "--overwrite",
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    deadline = time.monotonic() + 30
+    children = []
+    while time.monotonic() < deadline:
+        jobs = k8s.list_namespaced_custom_object(
+            GROUP,
+            VERSION,
+            NAMESPACE,
+            PLURAL,
+            label_selector=f"{LABEL_RECURRING_PARENT}=test-child-label",
+        )
+        children = jobs.get("items", [])
+        if children:
+            break
+        time.sleep(2)
+
+    assert len(children) >= 1, "Should be able to find children via label selector"
+    child_name = children[0]["metadata"]["name"]
+    assert child_name.startswith("test-child-label-"), (
+        f"Child name should start with parent name prefix, got {child_name!r}"
+    )

--- a/tests/test_deferred_scheduling.py
+++ b/tests/test_deferred_scheduling.py
@@ -36,7 +36,6 @@ def _spec(**overrides) -> dict:
     base = {
         "clusterless": True,
         "exclusive": False,
-        "pipeline": "forge-test-only",
         "executionEngine": {
             "forge": {
                 "project": "skeleton",


### PR DESCRIPTION
## Summary

- Adds `spec.scheduledStartTime` (ISO 8601 datetime) to defer a one-time job execution to a future time. The job enters a new `Scheduled` phase and automatically transitions to `Resolving` once the time is reached.
- Adds `spec.schedule` (cron expression, e.g. `0 20 * * *`) to turn a FournosJob into a recurring template. The operator creates child FournosJob CRs on each cron tick, labeled with `fournos.dev/recurring-parent` for querying.
- Both fields are optional and mutually exclusive. When neither is set, existing behavior is completely unchanged.

### Changes

| File | Change |
|---|---|
| `manifests/crd.yaml` | Added `scheduledStartTime`, `schedule`, `lastScheduledTime` fields; `Scheduled`/`Recurring` phases; printer columns |
| `fournos/core/constants.py` | Added `Phase.SCHEDULED`, `Phase.RECURRING`, `LABEL_RECURRING_PARENT` |
| `fournos/handlers/lifecycle.py` | Added `reconcile_scheduled`, `reconcile_recurring`, scheduling gate in `on_create`, cron validation |
| `fournos/operator.py` | Added `Scheduled`/`Recurring` to timer filter and reconcile routing |
| `fournos/handlers/__init__.py` | Exported new handlers |
| `pyproject.toml` | Added `croniter>=5.0` dependency |

### Example: one-time scheduled job

```yaml
apiVersion: fournos.dev/v1
kind: FournosJob
metadata:
  generateName: deferred-bench-
spec:
  owner: perf-team
  cluster: cluster-1
  scheduledStartTime: "2026-08-18T15:00:00Z"
  executionEngine:
    forge:
      project: llm-d
      args: [cks]
```

### Example: recurring job (every day at 20:00 UTC)

```yaml
apiVersion: fournos.dev/v1
kind: FournosJob
metadata:
  name: nightly-llm-bench
spec:
  owner: perf-team
  cluster: cluster-1
  schedule: "0 20 * * *"
  executionEngine:
    forge:
      project: llm-d
      args: [cks]
```

Query all child runs: `kubectl get fjobs -l fournos.dev/recurring-parent=nightly-llm-bench`

## Test plan

- [ ] Create a FournosJob without `scheduledStartTime` or `schedule` — verify existing behavior unchanged
- [ ] Create a FournosJob with `scheduledStartTime` set 1 minute in the future — verify it enters `Scheduled` phase and transitions to `Resolving` after the time passes
- [ ] Create a FournosJob with `scheduledStartTime` in the past — verify it starts immediately
- [ ] Create a FournosJob with an invalid `schedule` expression — verify it fails with a clear error
- [ ] Create a FournosJob with both `scheduledStartTime` and `schedule` — verify mutual exclusivity validation
- [ ] Create a FournosJob with `schedule: "*/1 * * * *"` — verify child jobs are created every minute with the `fournos.dev/recurring-parent` label
- [ ] Delete a recurring parent job — verify no more children are created

Made with [Cursor](https://cursor.com)