### PR TITLE
Add cluster unlock functionality to the cluster lock only mechanism 

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ oc delete FournosJob -n $FOURNOS_WORKLOAD_NAMESPACE <name>      # cleanup
 | `spec.secretRefs` | no | Vault-synced K8s Secret names (prefixed with `vault-`) to mount into the pipeline. Populated by the execution engine during the Resolving phase. The operator validates each name in `FOURNOS_SECRETS_NAMESPACE`, copies the secrets into the operator namespace, and mounts them as a projected volume at `/var/run/secrets/fournos/<entry-name>/`. |
 | `spec.exclusive` | no (default `true`) | If `true`, locks the target cluster so no other FournosJob can run there. Requires `spec.cluster`. Hardware is optional — when omitted the Workload only requests cluster-slot resources for locking. |
 | `spec.clusterless` | no (default `false`) | If `true`, runs without cluster access — no kubeconfig is passed to the execution environment. Cannot be combined with `cluster` or `exclusive: true`. Hardware specifications are optional — if omitted, the job runs on hub cluster resources without Kueue hardware scheduling. |
-| `spec.lockOnly` | no (default `false`) | Sentinel lock job: holds cluster-slot quota without running a pipeline. Implies `exclusive: true` and requires `cluster`. The job stays `Admitted` until deleted, shut down, or (with `lockUntil`) until it auto-expires. |
-| `spec.lockUntil` | no | Only valid with `lockOnly: true`. ISO 8601 UTC timestamp (e.g. `2026-08-23T22:00:00Z`) at which the lock is released automatically. Omit to hold the lock indefinitely. |
+| `spec.lockOnly` | no (default `false`, or `true` if `lockUntil` is set) | Sentinel lock job: holds cluster-slot quota without running a pipeline. Implies `exclusive: true` and requires `cluster`. The job stays `Admitted` until deleted, shut down, or (with `lockUntil`) until it auto-expires. If omitted, a bare `lockUntil` is enough to imply `lockOnly: true` — set `lockOnly: false` explicitly to reject a stray `lockUntil` instead. |
+| `spec.lockUntil` | no | ISO 8601 UTC timestamp (e.g. `2026-08-23T22:00:00Z`) at which the lock is released automatically. Implies `lockOnly: true` if `lockOnly` is omitted. Omit `lockUntil` to hold the lock indefinitely. |
 | `spec.scheduledStartTime` | no | ISO 8601 UTC timestamp (e.g. `2026-08-18T15:00:00Z`). When set, the job stays in `Scheduled` phase until this time, then proceeds to `Resolving`. Mutually exclusive with `schedule`. |
 | `spec.schedule` | no | Cron expression for recurring execution (e.g. `0 20 * * *`). The job enters `Recurring` phase and the operator creates child FournosJob CRs on each cron tick, labeled with `fournos.dev/recurring-parent`. Mutually exclusive with `scheduledStartTime`. |
 | `spec.shutdown` | no | Shutdown action: `Stop` cancels gracefully (Tekton `CancelledRunFinally` — runs `finally` tasks); `Terminate` cancels immediately (Tekton `Cancelled` — skips `finally` tasks). Both wait for the PipelineRun to finish before releasing Kueue quota. |
@@ -234,7 +234,7 @@ To stop recurring execution, delete the parent job.
 ## Temporary cluster locks
 
 To take a cluster out of scheduling for a fixed window (e.g. maintenance)
-without running any pipeline, submit a `lockOnly` job with `lockUntil`:
+without running any pipeline, submit a job with `lockUntil` set:
 
 ```yaml
 apiVersion: fournos.dev/v1
@@ -244,15 +244,20 @@ metadata:
 spec:
   cluster: cluster-2
   exclusive: true
-  lockOnly: true
   lockUntil: "2026-08-24T02:00:00Z" # 4 hours from now
 ```
 
-The job holds all cluster-slot quota for `cluster-2` — Kueue blocks every
-other job targeting that cluster — without deploying anything to the
-cluster itself. Once `lockUntil` is reached the operator releases the lock
-automatically (equivalent to `spec.shutdown: Terminate`). Omit `lockUntil`
-to hold the lock until the job is deleted or shut down manually.
+Setting `lockUntil` alone is enough — it implies `lockOnly: true`, so you
+don't need to write both fields. The job holds all cluster-slot quota for
+`cluster-2` — Kueue blocks every other job targeting that cluster — without
+deploying anything to the cluster itself. Once `lockUntil` is reached the
+operator releases the lock automatically (equivalent to
+`spec.shutdown: Terminate`).
+
+Omit `lockUntil` and set `lockOnly: true` explicitly to hold the lock
+indefinitely until the job is deleted or shut down manually. To reject a
+stray `lockUntil` on a normal (non-lock) job, set `lockOnly: false`
+explicitly alongside it.
 
 ## Local development
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ oc delete FournosJob -n $FOURNOS_WORKLOAD_NAMESPACE <name>      # cleanup
 | `spec.secretRefs` | no | Vault-synced K8s Secret names (prefixed with `vault-`) to mount into the pipeline. Populated by the execution engine during the Resolving phase. The operator validates each name in `FOURNOS_SECRETS_NAMESPACE`, copies the secrets into the operator namespace, and mounts them as a projected volume at `/var/run/secrets/fournos/<entry-name>/`. |
 | `spec.exclusive` | no (default `true`) | If `true`, locks the target cluster so no other FournosJob can run there. Requires `spec.cluster`. Hardware is optional — when omitted the Workload only requests cluster-slot resources for locking. |
 | `spec.clusterless` | no (default `false`) | If `true`, runs without cluster access — no kubeconfig is passed to the execution environment. Cannot be combined with `cluster` or `exclusive: true`. Hardware specifications are optional — if omitted, the job runs on hub cluster resources without Kueue hardware scheduling. |
+| `spec.lockOnly` | no (default `false`) | Sentinel lock job: holds cluster-slot quota without running a pipeline. Implies `exclusive: true` and requires `cluster`. The job stays `Admitted` until deleted, shut down, or (with `lockUntil`) until it auto-expires. |
+| `spec.lockUntil` | no | Only valid with `lockOnly: true`. ISO 8601 UTC timestamp (e.g. `2026-08-23T22:00:00Z`) at which the lock is released automatically. Omit to hold the lock indefinitely. |
 | `spec.scheduledStartTime` | no | ISO 8601 UTC timestamp (e.g. `2026-08-18T15:00:00Z`). When set, the job stays in `Scheduled` phase until this time, then proceeds to `Resolving`. Mutually exclusive with `schedule`. |
 | `spec.schedule` | no | Cron expression for recurring execution (e.g. `0 20 * * *`). The job enters `Recurring` phase and the operator creates child FournosJob CRs on each cron tick, labeled with `fournos.dev/recurring-parent`. Mutually exclusive with `scheduledStartTime`. |
 | `spec.shutdown` | no | Shutdown action: `Stop` cancels gracefully (Tekton `CancelledRunFinally` — runs `finally` tasks); `Terminate` cancels immediately (Tekton `Cancelled` — skips `finally` tasks). Both wait for the PipelineRun to finish before releasing Kueue quota. |
@@ -228,6 +230,29 @@ To stop recurring execution, delete the parent job.
 **Restrictions:**
 - `scheduledStartTime` and `schedule` are mutually exclusive
 - Invalid cron expressions or timestamps fail the job immediately
+
+## Temporary cluster locks
+
+To take a cluster out of scheduling for a fixed window (e.g. maintenance)
+without running any pipeline, submit a `lockOnly` job with `lockUntil`:
+
+```yaml
+apiVersion: fournos.dev/v1
+kind: FournosJob
+metadata:
+  name: maintenance-lock-cluster-2
+spec:
+  cluster: cluster-2
+  exclusive: true
+  lockOnly: true
+  lockUntil: "2026-08-24T02:00:00Z" # 4 hours from now
+```
+
+The job holds all cluster-slot quota for `cluster-2` — Kueue blocks every
+other job targeting that cluster — without deploying anything to the
+cluster itself. Once `lockUntil` is reached the operator releases the lock
+automatically (equivalent to `spec.shutdown: Terminate`). Omit `lockUntil`
+to hold the lock until the job is deleted or shut down manually.
 
 ## Local development
 

--- a/fournos/handlers/execution.py
+++ b/fournos/handlers/execution.py
@@ -16,7 +16,7 @@ from fournos.core.tekton import TektonClient
 from fournos.settings import settings
 from fournos.state import ctx
 
-from .lifecycle import parse_iso_timestamp
+from .lifecycle import is_lock_only, parse_iso_timestamp
 from .status import (
     COND_PIPELINE_RUN_READY,
     COND_WORKLOAD_ADMITTED,
@@ -144,7 +144,7 @@ def _finish_stop(name, conditions, patch, pr_message):
 
 
 def reconcile_admitted(spec, name, namespace, status, patch, body):
-    if spec.get("lockOnly", False):
+    if is_lock_only(spec):
         # lockUntil was already validated in on_create, so a parse failure
         # here shouldn't happen; treat it as "no deadline" rather than crash
         # the reconcile loop.

--- a/fournos/handlers/execution.py
+++ b/fournos/handlers/execution.py
@@ -145,8 +145,15 @@ def _finish_stop(name, conditions, patch, pr_message):
 
 def reconcile_admitted(spec, name, namespace, status, patch, body):
     if spec.get("lockOnly", False):
-        lock_until = parse_iso_timestamp(spec, "lockUntil")
-        if isinstance(lock_until, datetime) and datetime.now(UTC) >= lock_until:
+        # lockUntil was already validated in on_create, so a parse failure
+        # here shouldn't happen; treat it as "no deadline" rather than crash
+        # the reconcile loop.
+        try:
+            lock_until = parse_iso_timestamp(spec.get("lockUntil"), "lockUntil")
+        except ValueError:
+            logger.warning("Job %s: unexpected invalid lockUntil in spec", name)
+            lock_until = None
+        if lock_until is not None and datetime.now(UTC) >= lock_until:
             logger.info("Job %s: lockUntil reached (%s), releasing", name, lock_until)
             handle_shutdown(name, status, patch, Shutdown.TERMINATE)
             return

--- a/fournos/handlers/execution.py
+++ b/fournos/handlers/execution.py
@@ -151,7 +151,7 @@ def reconcile_admitted(spec, name, namespace, status, patch, body):
         try:
             lock_until = parse_iso_timestamp(spec.get("lockUntil"), "lockUntil")
         except ValueError:
-            logger.warning("Job %s: unexpected invalid lockUntil in spec", name)
+            logger.debug("Job %s: unexpected invalid lockUntil in spec", name)
             lock_until = None
         if lock_until is not None and datetime.now(UTC) >= lock_until:
             logger.info("Job %s: lockUntil reached (%s), releasing", name, lock_until)

--- a/fournos/handlers/execution.py
+++ b/fournos/handlers/execution.py
@@ -7,6 +7,7 @@ the Tekton PipelineRun.
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 
 from kubernetes import client
 
@@ -15,6 +16,7 @@ from fournos.core.tekton import TektonClient
 from fournos.settings import settings
 from fournos.state import ctx
 
+from .lifecycle import parse_iso_timestamp
 from .status import (
     COND_PIPELINE_RUN_READY,
     COND_WORKLOAD_ADMITTED,
@@ -143,6 +145,12 @@ def _finish_stop(name, conditions, patch, pr_message):
 
 def reconcile_admitted(spec, name, namespace, status, patch, body):
     if spec.get("lockOnly", False):
+        lock_until = parse_iso_timestamp(spec, "lockUntil")
+        if isinstance(lock_until, datetime) and datetime.now(UTC) >= lock_until:
+            logger.info("Job %s: lockUntil reached (%s), releasing", name, lock_until)
+            handle_shutdown(name, status, patch, Shutdown.TERMINATE)
+            return
+
         cluster = status.get("cluster", spec.get("cluster", ""))
         new_msg = f"Cluster lock held on {cluster}"
         if status.get("message") != new_msg:

--- a/fournos/handlers/lifecycle.py
+++ b/fournos/handlers/lifecycle.py
@@ -96,6 +96,16 @@ def on_create(spec, name, namespace, status, patch, body):
         patch.status["message"] = "lockOnly: true requires 'cluster' to be set"
         return
 
+    lock_until = parse_iso_timestamp(spec, "lockUntil")
+    if spec.get("lockUntil") and not lock_only:
+        patch.status["phase"] = Phase.FAILED
+        patch.status["message"] = "lockUntil requires lockOnly: true"
+        return
+    if isinstance(lock_until, str):
+        patch.status["phase"] = Phase.FAILED
+        patch.status["message"] = lock_until
+        return
+
     if not lock_only and not spec.get("executionEngine"):
         patch.status["phase"] = Phase.FAILED
         patch.status["message"] = (
@@ -154,9 +164,9 @@ def on_create(spec, name, namespace, status, patch, body):
 # ---------------------------------------------------------------------------
 
 
-def _parse_scheduled_time(spec) -> datetime | str | None:
-    """Return the parsed scheduledStartTime, None if absent, or an error string if invalid."""
-    raw = spec.get("scheduledStartTime")
+def parse_iso_timestamp(spec, field: str) -> datetime | str | None:
+    """Return the parsed *field* value, None if absent, or an error string if invalid."""
+    raw = spec.get(field)
     if raw is None:
         return None
     try:
@@ -165,7 +175,12 @@ def _parse_scheduled_time(spec) -> datetime | str | None:
             ts = ts.replace(tzinfo=UTC)
         return ts
     except (ValueError, TypeError):
-        return f"Invalid scheduledStartTime: {raw!r}"
+        return f"Invalid {field}: {raw!r}"
+
+
+def _parse_scheduled_time(spec) -> datetime | str | None:
+    """Return the parsed scheduledStartTime, None if absent, or an error string if invalid."""
+    return parse_iso_timestamp(spec, "scheduledStartTime")
 
 
 # ---------------------------------------------------------------------------

--- a/fournos/handlers/lifecycle.py
+++ b/fournos/handlers/lifecycle.py
@@ -56,11 +56,11 @@ def on_create(spec, name, namespace, status, patch, body):
         return
 
     cron_expr = spec.get("schedule")
-    scheduled_time = _parse_scheduled_time(spec)
-
-    if isinstance(scheduled_time, str):
+    try:
+        scheduled_time = _parse_scheduled_time(spec)
+    except ValueError as exc:
         patch.status["phase"] = Phase.FAILED
-        patch.status["message"] = scheduled_time
+        patch.status["message"] = str(exc)
         return
 
     if cron_expr and scheduled_time is not None:
@@ -96,14 +96,16 @@ def on_create(spec, name, namespace, status, patch, body):
         patch.status["message"] = "lockOnly: true requires 'cluster' to be set"
         return
 
-    lock_until = parse_iso_timestamp(spec, "lockUntil")
     if spec.get("lockUntil") and not lock_only:
         patch.status["phase"] = Phase.FAILED
         patch.status["message"] = "lockUntil requires lockOnly: true"
         return
-    if isinstance(lock_until, str):
+
+    try:
+        parse_iso_timestamp(spec.get("lockUntil"), "lockUntil")
+    except ValueError as exc:
         patch.status["phase"] = Phase.FAILED
-        patch.status["message"] = lock_until
+        patch.status["message"] = str(exc)
         return
 
     if not lock_only and not spec.get("executionEngine"):
@@ -164,23 +166,26 @@ def on_create(spec, name, namespace, status, patch, body):
 # ---------------------------------------------------------------------------
 
 
-def parse_iso_timestamp(spec, field: str) -> datetime | str | None:
-    """Return the parsed *field* value, None if absent, or an error string if invalid."""
-    raw = spec.get(field)
+def parse_iso_timestamp(raw: str | None, field: str) -> datetime | None:
+    """Parse *raw* as an ISO 8601 timestamp, defaulting to UTC if tz-naive.
+
+    Returns None if *raw* is None. Raises ValueError, naming *field*, if
+    *raw* is not a valid ISO 8601 timestamp.
+    """
     if raw is None:
         return None
     try:
         ts = datetime.fromisoformat(raw)
-        if ts.tzinfo is None:
-            ts = ts.replace(tzinfo=UTC)
-        return ts
-    except (ValueError, TypeError):
-        return f"Invalid {field}: {raw!r}"
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"Invalid {field}: {raw!r}") from exc
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=UTC)
+    return ts
 
 
-def _parse_scheduled_time(spec) -> datetime | str | None:
-    """Return the parsed scheduledStartTime, None if absent, or an error string if invalid."""
-    return parse_iso_timestamp(spec, "scheduledStartTime")
+def _parse_scheduled_time(spec) -> datetime | None:
+    """Return the parsed scheduledStartTime, or None if absent. Raises ValueError if invalid."""
+    return parse_iso_timestamp(spec.get("scheduledStartTime"), "scheduledStartTime")
 
 
 # ---------------------------------------------------------------------------
@@ -190,12 +195,13 @@ def _parse_scheduled_time(spec) -> datetime | str | None:
 
 def reconcile_scheduled(spec, name, namespace, status, patch, body):
     """Transition from Scheduled to the normal on_create flow once the time is reached."""
-    scheduled_time = _parse_scheduled_time(spec)
-    if isinstance(scheduled_time, str):
+    try:
+        scheduled_time = _parse_scheduled_time(spec)
+    except ValueError as exc:
         patch.status["phase"] = Phase.FAILED
-        patch.status["message"] = scheduled_time
+        patch.status["message"] = str(exc)
         return
-    if isinstance(scheduled_time, datetime) and datetime.now(UTC) < scheduled_time:
+    if scheduled_time is not None and datetime.now(UTC) < scheduled_time:
         return
 
     logger.info("Job %s: scheduled time reached, starting job", name)

--- a/fournos/handlers/lifecycle.py
+++ b/fournos/handlers/lifecycle.py
@@ -88,7 +88,7 @@ def on_create(spec, name, namespace, status, patch, body):
 
     cluster = spec.get("cluster")
     exclusive = spec["exclusive"]
-    lock_only = spec.get("lockOnly", False)
+    lock_only = is_lock_only(spec)
     clusterless = spec.get("clusterless", False)
 
     if lock_only and not cluster:
@@ -97,8 +97,10 @@ def on_create(spec, name, namespace, status, patch, body):
         return
 
     if spec.get("lockUntil") and not lock_only:
+        # lock_only is only False here if the user explicitly wrote
+        # lockOnly: false — a bare lockUntil already implies lockOnly: true.
         patch.status["phase"] = Phase.FAILED
-        patch.status["message"] = "lockUntil requires lockOnly: true"
+        patch.status["message"] = "lockUntil cannot be combined with lockOnly: false"
         return
 
     try:
@@ -164,6 +166,20 @@ def on_create(spec, name, namespace, status, patch, body):
 # ---------------------------------------------------------------------------
 # HELPERS
 # ---------------------------------------------------------------------------
+
+
+def is_lock_only(spec) -> bool:
+    """Return whether this spec describes a lockOnly job.
+
+    If ``lockOnly`` is set explicitly (true or false), that value wins.
+    If it's absent, it's inferred from the presence of ``lockUntil`` — a
+    bare ``lockUntil`` is enough to imply a timed lock job, so callers
+    don't have to write both fields together.
+    """
+    explicit = spec.get("lockOnly")
+    if explicit is not None:
+        return explicit
+    return bool(spec.get("lockUntil"))
 
 
 def parse_iso_timestamp(raw: str | None, field: str) -> datetime | None:

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -138,7 +138,6 @@ spec:
                     Kueue hardware scheduling.
                 lockOnly:
                   type: boolean
-                  default: false
                   description: >-
                     Sentinel lock job that holds cluster quota without running
                     a pipeline. Created by the hearth controller to
@@ -146,16 +145,20 @@ spec:
                     exclusive: true and requires 'cluster'. Skips execution
                     engine resolution and PipelineRun creation — the job
                     stays Admitted until deleted, or until lockUntil is
-                    reached if set.
+                    reached if set. If omitted, defaults to true when
+                    lockUntil is set and false otherwise — so a bare
+                    lockUntil is enough to create a timed lock job. Set
+                    explicitly to false to reject a stray lockUntil.
                 lockUntil:
                   type: string
                   format: date-time
                   description: >-
-                    Only used with lockOnly: true. If set, the lock is
-                    released automatically once this UTC timestamp is
-                    reached. ISO 8601 format (e.g. "2026-08-23T18:00:00Z").
-                    When omitted the lock is held indefinitely until the
-                    job is deleted or shut down.
+                    If set, the lock is released automatically once this UTC
+                    timestamp is reached. ISO 8601 format (e.g.
+                    "2026-08-23T18:00:00Z"). Setting this alone (without
+                    lockOnly) implies lockOnly: true. When omitted the lock
+                    is held indefinitely until the job is deleted or shut
+                    down.
                 priority:
                   type: string
                 scheduledStartTime:

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -40,6 +40,10 @@ spec:
           type: string
           jsonPath: .spec.schedule
           priority: 1
+        - name: Locked Until
+          type: string
+          jsonPath: .spec.lockUntil
+          priority: 1
         - name: Phase
           type: string
           jsonPath: .status.phase
@@ -141,7 +145,17 @@ spec:
                     implement human-driven cluster ownership. Implies
                     exclusive: true and requires 'cluster'. Skips execution
                     engine resolution and PipelineRun creation — the job
-                    stays Admitted indefinitely until deleted.
+                    stays Admitted until deleted, or until lockUntil is
+                    reached if set.
+                lockUntil:
+                  type: string
+                  format: date-time
+                  description: >-
+                    Only used with lockOnly: true. If set, the lock is
+                    released automatically once this UTC timestamp is
+                    reached. ISO 8601 format (e.g. "2026-08-23T18:00:00Z").
+                    When omitted the lock is held indefinitely until the
+                    job is deleted or shut down.
                 priority:
                   type: string
                 scheduledStartTime:

--- a/tests/test_cluster_lock.py
+++ b/tests/test_cluster_lock.py
@@ -1,0 +1,129 @@
+"""Cluster lock expiry tests — lockOnly jobs with a lockUntil deadline.
+
+A lockOnly job normally holds a cluster's slots until deleted or shut down
+by hand.  lockUntil is an absolute UTC timestamp (same style as
+scheduledStartTime) — the reconcile loop auto-releases the lock (same code
+path as a user-triggered shutdown) once that time passes.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from kubernetes.client.exceptions import ApiException
+import pytest
+
+from fournos.core.constants import Phase
+from tests.conftest import (
+    create_job,
+    get_job,
+    job_status_summary,
+    poll_phase,
+    workload_exists,
+)
+
+
+def _future(seconds: float) -> str:
+    return (datetime.now(UTC) + timedelta(seconds=seconds)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+
+def test_lock_until_without_lock_only_fails(k8s):
+    """lockUntil set without lockOnly: true is rejected."""
+    create_job(
+        k8s,
+        "test-lockuntil-no-lockonly",
+        {
+            "cluster": "cluster-2",
+            "exclusive": True,
+            "lockUntil": _future(3600),
+        },
+    )
+
+    phase = poll_phase(
+        k8s,
+        "test-lockuntil-no-lockonly",
+        terminal={Phase.FAILED},
+        timeout=15,
+    )
+    assert phase == Phase.FAILED, job_status_summary(k8s, "test-lockuntil-no-lockonly")
+
+    job = get_job(k8s, "test-lockuntil-no-lockonly")
+    assert "lockUntil" in job["status"]["message"]
+
+
+def test_invalid_lock_until_rejected_by_crd(k8s):
+    """Malformed lockUntil is rejected by CRD schema validation (422)."""
+    with pytest.raises(ApiException) as exc_info:
+        create_job(
+            k8s,
+            "test-lockuntil-bad-format",
+            {
+                "cluster": "cluster-2",
+                "exclusive": True,
+                "lockOnly": True,
+                "lockUntil": "not-a-date",
+            },
+        )
+    assert exc_info.value.status == 422
+
+
+def test_lock_auto_releases_at_lock_until(k8s):
+    """A lockOnly job with a near-future lockUntil self-releases and frees the cluster."""
+    create_job(
+        k8s,
+        "test-lock-ttl",
+        {
+            "cluster": "cluster-2",
+            "exclusive": True,
+            "lockOnly": True,
+            "lockUntil": _future(10),
+        },
+    )
+
+    phase = poll_phase(
+        k8s,
+        "test-lock-ttl",
+        terminal={Phase.ADMITTED},
+        timeout=30,
+    )
+    assert phase == Phase.ADMITTED, job_status_summary(k8s, "test-lock-ttl")
+    assert workload_exists("test-lock-ttl"), "Lock Workload should exist while held"
+
+    phase = poll_phase(
+        k8s,
+        "test-lock-ttl",
+        terminal={Phase.STOPPED},
+        timeout=45,
+    )
+    assert phase == Phase.STOPPED, job_status_summary(k8s, "test-lock-ttl")
+    assert not workload_exists("test-lock-ttl"), (
+        "Lock Workload should be deleted once lockUntil is reached"
+    )
+
+
+def test_lock_without_lock_until_holds_indefinitely(k8s):
+    """A lockOnly job with no lockUntil stays Admitted."""
+    create_job(
+        k8s,
+        "test-lock-no-ttl",
+        {"cluster": "cluster-3", "exclusive": True, "lockOnly": True},
+    )
+
+    phase = poll_phase(
+        k8s,
+        "test-lock-no-ttl",
+        terminal={Phase.ADMITTED},
+        timeout=30,
+    )
+    assert phase == Phase.ADMITTED, job_status_summary(k8s, "test-lock-no-ttl")
+
+    phase = poll_phase(
+        k8s,
+        "test-lock-no-ttl",
+        terminal={Phase.STOPPED},
+        timeout=15,
+        raise_on_timeout=False,
+    )
+    assert phase == Phase.ADMITTED, (
+        f"Lock without lockUntil should still be held, got phase={phase!r}"
+    )

--- a/tests/test_cluster_lock.py
+++ b/tests/test_cluster_lock.py
@@ -155,29 +155,3 @@ def test_lock_until_already_past_self_releases_quickly(k8s):
     assert not workload_exists("test-lock-past-ttl"), (
         "Lock Workload should be deleted once the (already-past) lockUntil is reached"
     )
-
-
-def test_lock_until_valid_format_but_naive_datetime_treated_as_utc(k8s):
-    """A lockUntil without an explicit 'Z'/offset is treated as UTC (same
-    convention as scheduledStartTime), not rejected and not interpreted in
-    local time.
-    """
-    naive_past = (datetime.now(UTC) - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S")
-    create_job(
-        k8s,
-        "test-lock-naive-ttl",
-        {
-            "cluster": "cluster-3",
-            "exclusive": True,
-            "lockOnly": True,
-            "lockUntil": naive_past,
-        },
-    )
-
-    phase = poll_phase(
-        k8s,
-        "test-lock-naive-ttl",
-        terminal={Phase.STOPPED, Phase.FAILED},
-        timeout=30,
-    )
-    assert phase == Phase.STOPPED, job_status_summary(k8s, "test-lock-naive-ttl")

--- a/tests/test_cluster_lock.py
+++ b/tests/test_cluster_lock.py
@@ -27,11 +27,11 @@ def _future(seconds: float) -> str:
     )
 
 
-def test_lock_until_without_lock_only_fails(k8s):
-    """lockUntil set without lockOnly: true is rejected."""
+def test_bare_lock_until_implies_lock_only(k8s):
+    """A bare lockUntil (no lockOnly field at all) implies lockOnly: true."""
     create_job(
         k8s,
-        "test-lockuntil-no-lockonly",
+        "test-lockuntil-implied",
         {
             "cluster": "cluster-2",
             "exclusive": True,
@@ -41,13 +41,40 @@ def test_lock_until_without_lock_only_fails(k8s):
 
     phase = poll_phase(
         k8s,
-        "test-lockuntil-no-lockonly",
+        "test-lockuntil-implied",
+        terminal={Phase.ADMITTED},
+        timeout=30,
+    )
+    assert phase == Phase.ADMITTED, job_status_summary(k8s, "test-lockuntil-implied")
+    assert workload_exists("test-lockuntil-implied"), (
+        "Lock Workload should exist for an implied lockOnly job"
+    )
+
+
+def test_lock_until_with_explicit_lock_only_false_fails(k8s):
+    """lockUntil combined with an explicit lockOnly: false is a contradiction."""
+    create_job(
+        k8s,
+        "test-lockuntil-explicit-false",
+        {
+            "cluster": "cluster-2",
+            "exclusive": True,
+            "lockOnly": False,
+            "lockUntil": _future(3600),
+        },
+    )
+
+    phase = poll_phase(
+        k8s,
+        "test-lockuntil-explicit-false",
         terminal={Phase.FAILED},
         timeout=15,
     )
-    assert phase == Phase.FAILED, job_status_summary(k8s, "test-lockuntil-no-lockonly")
+    assert phase == Phase.FAILED, job_status_summary(
+        k8s, "test-lockuntil-explicit-false"
+    )
 
-    job = get_job(k8s, "test-lockuntil-no-lockonly")
+    job = get_job(k8s, "test-lockuntil-explicit-false")
     assert "lockUntil" in job["status"]["message"]
 
 

--- a/tests/test_cluster_lock.py
+++ b/tests/test_cluster_lock.py
@@ -127,3 +127,59 @@ def test_lock_without_lock_until_holds_indefinitely(k8s):
     assert phase == Phase.ADMITTED, (
         f"Lock without lockUntil should still be held, got phase={phase!r}"
     )
+
+
+def test_lock_until_already_past_self_releases_quickly(k8s):
+    """A lockOnly job created with a lockUntil already in the past is admitted
+    and then released on the very next reconcile tick, rather than being
+    rejected outright at creation time.
+    """
+    create_job(
+        k8s,
+        "test-lock-past-ttl",
+        {
+            "cluster": "cluster-2",
+            "exclusive": True,
+            "lockOnly": True,
+            "lockUntil": _future(-3600),
+        },
+    )
+
+    phase = poll_phase(
+        k8s,
+        "test-lock-past-ttl",
+        terminal={Phase.STOPPED, Phase.FAILED},
+        timeout=30,
+    )
+    assert phase == Phase.STOPPED, job_status_summary(k8s, "test-lock-past-ttl")
+    assert not workload_exists("test-lock-past-ttl"), (
+        "Lock Workload should be deleted once the (already-past) lockUntil is reached"
+    )
+
+
+def test_lock_until_valid_format_but_naive_datetime_treated_as_utc(k8s):
+    """A lockUntil without an explicit 'Z'/offset is treated as UTC (same
+    convention as scheduledStartTime), not rejected and not interpreted in
+    local time.
+    """
+    naive_past = (datetime.now(UTC) - timedelta(hours=1)).strftime(
+        "%Y-%m-%dT%H:%M:%S"
+    )
+    create_job(
+        k8s,
+        "test-lock-naive-ttl",
+        {
+            "cluster": "cluster-3",
+            "exclusive": True,
+            "lockOnly": True,
+            "lockUntil": naive_past,
+        },
+    )
+
+    phase = poll_phase(
+        k8s,
+        "test-lock-naive-ttl",
+        terminal={Phase.STOPPED, Phase.FAILED},
+        timeout=30,
+    )
+    assert phase == Phase.STOPPED, job_status_summary(k8s, "test-lock-naive-ttl")

--- a/tests/test_cluster_lock.py
+++ b/tests/test_cluster_lock.py
@@ -162,9 +162,7 @@ def test_lock_until_valid_format_but_naive_datetime_treated_as_utc(k8s):
     convention as scheduledStartTime), not rejected and not interpreted in
     local time.
     """
-    naive_past = (datetime.now(UTC) - timedelta(hours=1)).strftime(
-        "%Y-%m-%dT%H:%M:%S"
-    )
+    naive_past = (datetime.now(UTC) - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S")
     create_job(
         k8s,
         "test-lock-naive-ttl",

--- a/tests/test_cluster_lock.py
+++ b/tests/test_cluster_lock.py
@@ -8,8 +8,8 @@ path as a user-triggered shutdown) once that time passes.
 
 from datetime import UTC, datetime, timedelta
 
-from kubernetes.client.exceptions import ApiException
 import pytest
+from kubernetes.client.exceptions import ApiException
 
 from fournos.core.constants import Phase
 from tests.conftest import (


### PR DESCRIPTION
This PR allows to unlock the cluster after it was locked continuing the work for lock only operations. 

spec.lockOnly -  holds cluster-slot quota without running a pipeline. Implies `exclusive: true` and requires `cluster`. The job stays `Admitted` until deleted, shut down, or (with `lockUntil`) until it auto-expires.
spec.lockUntil -  Only valid with 'lockOnly: true' . ISO 8601 UTC timestamp (e.g., 2026-08-23T22:00:00Z) at which the lock is released automatically. Omit to hold the lock indefinitely. 